### PR TITLE
Support for Nested Objects & Custom Schema Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,30 @@ var myPet = new Pet({
 myPet.save();
 ```
 
+```js
+var swaggerMongoose = require('swagger-mongoose');
+
+var swagger = fs.readFileSync('./petstore.json');
+var Pet = swaggerMongoose.compile(swagger, { default: { timestamps: true } }).models.Pet;
+var myPet = new Pet({
+    id: 123,
+    name: 'Fluffy'
+    });
+myPet.save();
+```
+
+```js
+var swaggerMongoose = require('swagger-mongoose');
+
+var swagger = fs.readFileSync('./petstore.json');
+var Pet = swaggerMongoose.compile(swagger, { default: { timestamps: true }, MySchema: { timestamps: false } }).models.Pet;
+var myPet = new Pet({
+    id: 123,
+    name: 'Fluffy'
+    });
+myPet.save();
+```
+
 ## Installation
 
 ```js
@@ -27,7 +51,7 @@ npm install swagger-mongoose
 
 ## Limitations
 
-swagger-mongoose supports the following attributes: integer, long, float, double, string, password, boolean, date, dateTime, array (including nested schemas). swagger-mongoose also supports relationships between objects in a swagger document (thanks to @buchslava)
+swagger-mongoose supports the following attributes: integer, long, float, double, string, password, boolean, date, dateTime, object, array (including nested schemas). swagger-mongoose also supports relationships between objects in a swagger document (thanks to @buchslava)
 
 swagger-mongoose does not yet perform/create any validation from the swagger definitions (see issues if you'd like to help)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -168,10 +168,13 @@ var getSchema = function (objectName, fullObject) {
     else if (isPropertyHasRef(property)) {
       processRef(property, objectName, props, key, required);
     }
-    else if (property.type) {
+    else if (property.type !== 'object') {
       var type = propertyMap(property);
       props[key] = {type: type};
       fillRequired(props, key, required);
+    }
+    else if (property.type === 'object') {
+      props[key] = getSchema(key, property);
     }
     else if (isSimpleSchema(object)) {
       props = {type: propertyMap(object)};
@@ -189,7 +192,7 @@ module.exports.compileAsync = function (spec, callback) {
   }
 };
 
-module.exports.compile = function (spec, _extraDefinitions) {
+module.exports.compile = function (spec, _extraDefinitions, schemaOptions) {
   if (!spec) throw new Error('Swagger spec not supplied');
 
   var swaggerJSON = convertToJSON(spec);
@@ -199,7 +202,11 @@ module.exports.compile = function (spec, _extraDefinitions) {
   var schemas = {};
   _.forEach(definitions, function (definition, key) {
     var object = getSchema(key, definition);
-    schemas[key] = new mongoose.Schema(object);
+    var options = {};
+    if (schemaOptions) {
+      options = _.extend(options, schemaOptions.default, schemaOptions[key]);
+    }
+    schemas[key] = new mongoose.Schema(object, options);
   });
 
   var models = {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -184,15 +184,15 @@ var getSchema = function (objectName, fullObject) {
   return props;
 };
 
-module.exports.compileAsync = function (spec, callback) {
+module.exports.compileAsync = function (spec, schemaOptions, callback) {
   try {
-    callback(null, this.compile(spec));
+    callback(null, this.compile(spec, schemaOptions));
   } catch (err) {
     callback({message: err}, null);
   }
 };
 
-module.exports.compile = function (spec, _extraDefinitions, schemaOptions) {
+module.exports.compile = function (spec, schemaOptions, _extraDefinitions) {
   if (!spec) throw new Error('Swagger spec not supplied');
 
   var swaggerJSON = convertToJSON(spec);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-mongoose",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Generate mongoose schemas and models from swagger documents",
   "main": "./lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -7,15 +7,15 @@
     "test": "test"
   },
   "dependencies": {
-    "lodash": "^3.6.0"
+    "lodash": "^4.6.1"
   },
   "devDependencies": {
-    "async": "^1.5.0",
-    "chai": "^2.2.0",
-    "mocha": "^2.2.1",
-    "mockgoose": "^1.10.7",
-    "mongodb": "^2.0.47",
-    "mongoose": "^4.0.1"
+    "async": "^2.0.0-rc.1",
+    "chai": "^3.5.0",
+    "mocha": "^2.4.5",
+    "mockgoose": "^2.1.1",
+    "mongodb": "^2.1.11",
+    "mongoose": "^4.4.9"
   },
   "scripts": {
     "test": "mocha"

--- a/test/person.json
+++ b/test/person.json
@@ -106,6 +106,17 @@
           "items": {
             "$ref": "#/definitions/Car"
           }
+        },
+        "phone": {
+          "type": "object",
+          "properties": {
+            "home": {
+              "type": "string"
+            },
+            "mobile": {
+              "type": "string"
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
## Changes
- Allows custom schema options when compiling
- Allows properties of type object for nested documents
- Not entirely sure what `_extraDefinitions` is used for (Would love to see an example) but swapped the parameter position so that the new schemaOptions could easily be added to the compileAsync method
- Added examples to the README and updated to show support for properties of type `object`
- Bumped version number

**Example**
`swaggerMongoose.compile(swaggerDoc, { default: { timestamps: true } });`

This should also allow specific Schemas to have their own schema options that should override the default (~~**I haven't completely tested this yet -- Will test this and confirm that this works**~~)

`swaggerMongoose.compile(swaggerDoc, { default: { timestamps: true }, MySchema: { timestamps: false } });`

@simonguest - Let me know if there is anything here that needs changing
