### PR TITLE
Custom v2 x-swagger-mongoose properties to extend functionality AND nested objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,30 @@ var myPet = new Pet({
 myPet.save();
 ```
 
+```js
+var swaggerMongoose = require('swagger-mongoose');
+
+var swagger = fs.readFileSync('./petstore.json');
+var Pet = swaggerMongoose.compile(swagger, { default: { timestamps: true } }).models.Pet;
+var myPet = new Pet({
+    id: 123,
+    name: 'Fluffy'
+    });
+myPet.save();
+```
+
+```js
+var swaggerMongoose = require('swagger-mongoose');
+
+var swagger = fs.readFileSync('./petstore.json');
+var Pet = swaggerMongoose.compile(swagger, { default: { timestamps: true }, MySchema: { timestamps: false } }).models.Pet;
+var myPet = new Pet({
+    id: 123,
+    name: 'Fluffy'
+    });
+myPet.save();
+```
+
 ## Installation
 
 ```js
@@ -27,7 +51,7 @@ npm install swagger-mongoose
 
 ## Limitations
 
-swagger-mongoose supports the following attributes: integer, long, float, double, string, password, boolean, date, dateTime, array (including nested schemas). swagger-mongoose also supports relationships between objects in a swagger document (thanks to @buchslava)
+swagger-mongoose supports the following attributes: integer, long, float, double, string, password, boolean, date, dateTime, object, array (including nested schemas). swagger-mongoose also supports relationships between objects in a swagger document (thanks to @buchslava)
 
 swagger-mongoose does not yet perform/create any validation from the swagger definitions (see issues if you'd like to help)
 

--- a/README.md
+++ b/README.md
@@ -19,28 +19,63 @@ var myPet = new Pet({
 myPet.save();
 ```
 
-```js
-var swaggerMongoose = require('swagger-mongoose');
+There are 3 different use cases and 3 new custom options available for the new ```x-swagger-mongoose``` custom property for Swagger documents that are v2 and greater.
 
-var swagger = fs.readFileSync('./petstore.json');
-var Pet = swaggerMongoose.compile(swagger, { default: { timestamps: true } }).models.Pet;
-var myPet = new Pet({
-    id: 123,
-    name: 'Fluffy'
-    });
-myPet.save();
+Custom options include: ```schema-options```, ```additional-properties```, and ```exclude-schema```
+
+By default the ```exclude-schema``` option is set to false.
+
+Global Schema Options
+```js
+x-swagger-mongoose:
+  schema-options:
+    timestamps: true
+definitions:
+  User: ...
 ```
 
+Per-Schema Options
 ```js
-var swaggerMongoose = require('swagger-mongoose');
+  User:
+    type: object
+    x-swagger-mongoose:
+      schema-options:
+          timestamps: true
+```
 
-var swagger = fs.readFileSync('./petstore.json');
-var Pet = swaggerMongoose.compile(swagger, { default: { timestamps: true }, MySchema: { timestamps: false } }).models.Pet;
-var myPet = new Pet({
-    id: 123,
-    name: 'Fluffy'
-    });
-myPet.save();
+Swagger Validation requires String but Schema defined as a reference
+```js
+  User:
+    type: object
+    properties:
+      otherSchema:
+        type: string
+        x-swagger-mongoose:
+          $ref: "#/definitions/OtherSchema"
+```
+
+Additional Mongo Schema paths that are not shown in Swagger-UI Documentation
+```js
+  SchemaName:
+    type: object
+    x-swagger-mongoose:
+      additional-properties:
+        user:
+          $ref: "#/definitions/User"
+        approved:
+          type: string
+          format: datetime
+        rejected:
+          type: string
+          format: datetime
+```
+
+No Mongo Schema created for this definition
+```js
+  ExcludedSchema:
+    type: object
+    x-swagger-mongoose:
+      exclude-schema: true
 ```
 
 ## Installation

--- a/lib/index.js
+++ b/lib/index.js
@@ -168,10 +168,13 @@ var getSchema = function (objectName, fullObject) {
     else if (isPropertyHasRef(property)) {
       processRef(property, objectName, props, key, required);
     }
-    else if (property.type) {
+    else if (property.type !== 'object') {
       var type = propertyMap(property);
       props[key] = {type: type};
       fillRequired(props, key, required);
+    }
+    else if (property.type === 'object') {
+      props[key] = getSchema(key, property);
     }
     else if (isSimpleSchema(object)) {
       props = {type: propertyMap(object)};
@@ -189,7 +192,7 @@ module.exports.compileAsync = function (spec, callback) {
   }
 };
 
-module.exports.compile = function (spec, _extraDefinitions) {
+module.exports.compile = function (spec, _extraDefinitions, schemaOptions) {
   if (!spec) throw new Error('Swagger spec not supplied');
 
   var swaggerJSON = convertToJSON(spec);
@@ -199,7 +202,11 @@ module.exports.compile = function (spec, _extraDefinitions) {
   var schemas = {};
   _.forEach(definitions, function (definition, key) {
     var object = getSchema(key, definition);
-    schemas[key] = new mongoose.Schema(object);
+    var options = {};
+    if (schemaOptions) {
+      options = _.extend(options, schemaOptions.default, schemaOptions[key]);
+    }
+    schemas[key] = new mongoose.Schema(object, options);
   });
 
   var models = {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,9 @@ var Schema = mongoose.Schema;
 
 var allowedTypes = ['number','integer', 'long', 'float', 'double', 'string', 'password', 'boolean', 'date', 'dateTime', 'array'];
 var definitions = null;
+var swaggerVersion = null;
+var v2MongooseProperty = 'x-swagger-mongoose';
+var v1MongooseProperty = '_mongoose';
 
 var propertyMap = function (property) {
   switch (property.type) {
@@ -68,7 +71,7 @@ var isAllowedType = function (type) {
 };
 
 var isPropertyHasRef = function (property) {
-  return property['$ref'] || ((property['type'] == 'array') && (property['items']['$ref'])) || property['x-swagger-mongoose-ref'];
+  return property['$ref'] || ((property['type'] == 'array') && (property['items']['$ref']));
 };
 
 var fillRequired = function (object, key, template) {
@@ -80,6 +83,7 @@ var fillRequired = function (object, key, template) {
 var applyExtraDefinitions = function (definitions, _extraDefinitions) {
   if (_extraDefinitions) {
     var extraDefinitions = JSON.parse(_extraDefinitions);
+    var mongooseProperty = getMongooseProperty();
     _.each(extraDefinitions, function (val, key) {
       var s = key.split('.');
       var _definition = definitions;
@@ -90,26 +94,35 @@ var applyExtraDefinitions = function (definitions, _extraDefinitions) {
 
         _definition = _definition[s[i]];
       }
-      _definition._mongoose = val;
+      _definition[mongooseProperty] = val;
     });
   }
 };
 
+var isAtLeastSwagger2 = function() {
+  return swaggerVersion >= 2;
+};
+
+var getMongooseProperty = function() {
+  return (isAtLeastSwagger2()) ? v2MongooseProperty : v1MongooseProperty;
+};
+
 var isMongooseProperty = function (property) {
-  return !!property._mongoose;
+  return !!property[getMongooseProperty()];
 };
 
 var isMongooseArray = function (property) {
-  return property.items && property.items._mongoose;
+  return property.items && property.items[getMongooseProperty()];
 };
 
 var getMongooseSpecific = function (props, property) {
-  var mongooseSpecific = property._mongoose;
-  var ref = property.$ref;
+  var mongooseProperty = getMongooseProperty();
+  var mongooseSpecific = property[mongooseProperty];
+  var ref = (isAtLeastSwagger2() && mongooseSpecific) ? mongooseSpecific.$ref : property.$ref;
 
   if (!mongooseSpecific && isMongooseArray(property)) {
-    mongooseSpecific = property.items._mongoose;
-    ref = property.items.$ref;
+    mongooseSpecific = property.items[mongooseProperty];
+    ref = (isAtLeastSwagger2()) ? mongooseSpecific.$ref : property.items.$ref;
   }
 
   if (!mongooseSpecific) {
@@ -118,11 +131,16 @@ var getMongooseSpecific = function (props, property) {
 
   var ret = {};
 
-  if (mongooseSpecific.type === 'objectId') {
-    ret.type = Schema.Types.ObjectId;
-    if (mongooseSpecific.includeSwaggerRef !== false) {
-      ret.ref = ref.replace('#/definitions/', '');
+  if (!isAtLeastSwagger2()) {
+    if (mongooseSpecific.type === 'objectId') {
+      ret.type = Schema.Types.ObjectId;
+      if (mongooseSpecific.includeSwaggerRef !== false) {
+        ret.ref = ref.replace('#/definitions/', '');
+      }
     }
+  } else {
+    ret.type = Schema.Types.ObjectId;
+    ret.ref = ref.replace('#/definitions/', '');
   }
 
   return ret;
@@ -134,17 +152,19 @@ var isMongodbReserved = function (fieldKey) {
 
 var processRef = function (property, objectName, props, key, required) {
   var refRegExp = /^#\/definitions\/(\w*)$/;
-  var refString = property['$ref'] ? property['$ref'] : property['items']['$ref'] ? property['items']['$ref'] : property['x-swagger-mongoose-ref'];
+  var refString = property['$ref'] ? property['$ref'] : property['items']['$ref'];
   var propType = refString.match(refRegExp)[1];
   if (propType !== objectName) {
     // NOT circular reference
     props[key] = [getSchema(propType, definitions[propType]['properties'] ? definitions[propType]['properties'] : definitions[propType])];
   } else {
     // circular reference
-    props[key] = {
-      type: Schema.Types.ObjectId,
-      ref: objectName
-    };
+    if (propType) {
+      props[key] = {
+        type: Schema.Types.ObjectId,
+        ref: propType
+      };
+    }
   }
   fillRequired(props, key, required);
 };
@@ -196,6 +216,9 @@ module.exports.compile = function (spec, schemaOptions, _extraDefinitions) {
   if (!spec) throw new Error('Swagger spec not supplied');
 
   var swaggerJSON = convertToJSON(spec);
+  if (swaggerJSON.swagger) {
+    swaggerVersion = new Number(swaggerJSON.swagger);
+  }
   definitions = swaggerJSON['definitions'];
   applyExtraDefinitions(definitions, _extraDefinitions);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -184,15 +184,15 @@ var getSchema = function (objectName, fullObject) {
   return props;
 };
 
-module.exports.compileAsync = function (spec, callback) {
+module.exports.compileAsync = function (spec, schemaOptions, callback) {
   try {
-    callback(null, this.compile(spec));
+    callback(null, this.compile(spec, schemaOptions));
   } catch (err) {
     callback({message: err}, null);
   }
 };
 
-module.exports.compile = function (spec, _extraDefinitions, schemaOptions) {
+module.exports.compile = function (spec, schemaOptions, _extraDefinitions) {
   if (!spec) throw new Error('Swagger spec not supplied');
 
   var swaggerJSON = convertToJSON(spec);

--- a/lib/index.js
+++ b/lib/index.js
@@ -151,7 +151,8 @@ var getMongooseSpecific = function (props, property) {
       ret.ref = ref.replace('#/definitions/', '');
     }
   } else {
-    ret = _.extend(ret, mongooseSpecific);
+    ret = _.extend(ret, property, mongooseSpecific);
+    delete ret[mongooseProperty];
   }
 
   return ret;
@@ -260,7 +261,7 @@ module.exports.compile = function (spec, _extraDefinitions) {
     }
     object = getSchema(key, definition);
     if (options) {
-      options = _.extend(options[customMongooseProperty], options[key]);
+      options = _.extend({}, options[customMongooseProperty], options[key]);
     }
     if (typeof excludedSchema === 'object') {
       excludedSchema = excludedSchema[customMongooseProperty] || excludedSchema[key];

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,11 @@ var definitions = null;
 var swaggerVersion = null;
 var v2MongooseProperty = 'x-swagger-mongoose';
 var v1MongooseProperty = '_mongoose';
+var xSwaggerMongoose = {
+  schemaOptions: {},
+  additionalProperties: {},
+  excludeSchema: {}
+};
 
 var propertyMap = function (property) {
   switch (property.type) {
@@ -75,8 +80,10 @@ var isPropertyHasRef = function (property) {
 };
 
 var fillRequired = function (object, key, template) {
-  if (template.indexOf(key) >= 0) {
+  if (template && Array.isArray(template) && template.indexOf(key) >= 0) {
     object[key].required = true;
+  } else if (typeof template === 'boolean') {
+    object[key].required = template;
   }
 };
 
@@ -139,6 +146,7 @@ var getMongooseSpecific = function (props, property) {
       }
     }
   } else {
+
     ret.type = Schema.Types.ObjectId;
     ret.ref = ref.replace('#/definitions/', '');
   }
@@ -175,44 +183,53 @@ var getSchema = function (objectName, fullObject) {
   var object = fullObject['properties'] ? fullObject['properties'] : fullObject;
 
   _.forEach(object, function (property, key) {
-    if (isMongodbReserved(key) === true) {
-      return;
-    }
-
-    if (isMongooseProperty(property)) {
-      props[key] = getMongooseSpecific(props, property);
-    }
-    else if (isMongooseArray(property)) {
-      props[key] = [getMongooseSpecific(props, property)];
-    }
-    else if (isPropertyHasRef(property)) {
-      processRef(property, objectName, props, key, required);
-    }
-    else if (property.type !== 'object') {
-      var type = propertyMap(property);
-      props[key] = {type: type};
-      fillRequired(props, key, required);
-    }
-    else if (property.type === 'object') {
-      props[key] = getSchema(key, property);
-    }
-    else if (isSimpleSchema(object)) {
-      props = {type: propertyMap(object)};
-    }
+    var schemaProperty = getSchemaProperty(property, key, required, objectName, object);
+    props = _.extend(props, schemaProperty);
   });
 
   return props;
 };
 
-module.exports.compileAsync = function (spec, schemaOptions, callback) {
+var getSchemaProperty = function(property, key, required, objectName, object) {
+  var props = {};
+  if (isMongodbReserved(key) === true) {
+    return;
+  }
+
+  if (isMongooseProperty(property)) {
+    props[key] = getMongooseSpecific(props, property);
+  }
+  else if (isMongooseArray(property)) {
+    props[key] = [getMongooseSpecific(props, property)];
+  }
+  else if (isPropertyHasRef(property)) {
+    processRef(property, objectName, props, key, required);
+  }
+  else if (property.type !== 'object') {
+    var type = propertyMap(property);
+    props[key] = {type: type};
+  }
+  else if (property.type === 'object') {
+    props[key] = getSchema(key, property);
+  }
+  else if (isSimpleSchema(object)) {
+    props = {type: propertyMap(object)};
+  }
+  if (required) {
+    fillRequired(props, key, required);
+  }
+  return props;
+};
+
+module.exports.compileAsync = function (spec, callback) {
   try {
-    callback(null, this.compile(spec, schemaOptions));
+    callback(null, this.compile(spec));
   } catch (err) {
     callback({message: err}, null);
   }
 };
 
-module.exports.compile = function (spec, schemaOptions, _extraDefinitions) {
+module.exports.compile = function (spec, _extraDefinitions) {
   if (!spec) throw new Error('Swagger spec not supplied');
 
   var swaggerJSON = convertToJSON(spec);
@@ -222,14 +239,35 @@ module.exports.compile = function (spec, schemaOptions, _extraDefinitions) {
   definitions = swaggerJSON['definitions'];
   applyExtraDefinitions(definitions, _extraDefinitions);
 
+  var customMongooseProperty = getMongooseProperty();
+
+  if (swaggerJSON[customMongooseProperty]) {
+    processMongooseDefinition(customMongooseProperty, swaggerJSON[customMongooseProperty]);
+  }
+
   var schemas = {};
   _.forEach(definitions, function (definition, key) {
-    var object = getSchema(key, definition);
-    var options = {};
-    if (schemaOptions) {
-      options = _.extend(options, schemaOptions.default, schemaOptions[key]);
+
+    var object = null;
+    var options = xSwaggerMongoose.schemaOptions;
+    var excludedSchema = xSwaggerMongoose.excludeSchema;
+
+    if (definition[customMongooseProperty]) {
+      processMongooseDefinition(key, definition[customMongooseProperty]);
     }
-    schemas[key] = new mongoose.Schema(object, options);
+    object = getSchema(key, definition);
+    if (options) {
+      options = _.extend(options[customMongooseProperty], options[key]);
+    }
+    if (typeof excludedSchema === 'object') {
+      excludedSchema = excludedSchema[customMongooseProperty] || excludedSchema[key];
+    }
+    if (object && !excludedSchema) {
+      var additionalProperties = _.extend({}, xSwaggerMongoose.additionalProperties[customMongooseProperty], xSwaggerMongoose.additionalProperties[key]);
+      additionalProperties = processAdditionalProperties(additionalProperties, key)
+      object = _.extend(object, additionalProperties);
+      schemas[key] = new mongoose.Schema(object, options);
+    }
   });
 
   var models = {};
@@ -241,4 +279,29 @@ module.exports.compile = function (spec, schemaOptions, _extraDefinitions) {
     schemas: schemas,
     models: models
   };
+};
+
+var processMongooseDefinition = function(key, customOptions) {
+  if (customOptions) {
+    if (customOptions['schema-options']) {
+      xSwaggerMongoose.schemaOptions[key] = customOptions['schema-options'];
+    }
+    if (customOptions['exclude-schema']) {
+      xSwaggerMongoose.excludeSchema[key] = customOptions['exclude-schema'];
+    }
+    if (customOptions['additional-properties']) {
+      xSwaggerMongoose.additionalProperties[key] = customOptions['additional-properties'];
+    }
+  }
+};
+
+var processAdditionalProperties = function(additionalProperties, objectName) {
+  var props = {};
+  var customMongooseProperty = getMongooseProperty();
+  _.each(additionalProperties, function (property, key) {
+    var modifiedProperty = {};
+    modifiedProperty[customMongooseProperty] = property;
+    props = _.extend(props, getSchemaProperty(modifiedProperty, key, property.required, objectName));
+  });
+  return props;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -138,17 +138,20 @@ var getMongooseSpecific = function (props, property) {
 
   var ret = {};
 
-  if (!isAtLeastSwagger2()) {
-    if (mongooseSpecific.type === 'objectId') {
-      ret.type = Schema.Types.ObjectId;
-      if (mongooseSpecific.includeSwaggerRef !== false) {
-        ret.ref = ref.replace('#/definitions/', '');
+  if (ref) {
+    if (!isAtLeastSwagger2()) {
+      if (mongooseSpecific.type === 'objectId') {
+        ret.type = Schema.Types.ObjectId;
+        if (mongooseSpecific.includeSwaggerRef !== false) {
+          ret.ref = ref.replace('#/definitions/', '');
+        }
       }
+    } else {
+      ret.type = Schema.Types.ObjectId;
+      ret.ref = ref.replace('#/definitions/', '');
     }
   } else {
-
-    ret.type = Schema.Types.ObjectId;
-    ret.ref = ref.replace('#/definitions/', '');
+    ret = _.extend(ret, mongooseSpecific);
   }
 
   return ret;

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,7 +68,7 @@ var isAllowedType = function (type) {
 };
 
 var isPropertyHasRef = function (property) {
-  return property['$ref'] || ((property['type'] == 'array') && (property['items']['$ref']));
+  return property['$ref'] || ((property['type'] == 'array') && (property['items']['$ref'])) || property['x-swagger-mongoose-ref'];
 };
 
 var fillRequired = function (object, key, template) {
@@ -134,7 +134,7 @@ var isMongodbReserved = function (fieldKey) {
 
 var processRef = function (property, objectName, props, key, required) {
   var refRegExp = /^#\/definitions\/(\w*)$/;
-  var refString = property['$ref'] ? property['$ref'] : property['items']['$ref'];
+  var refString = property['$ref'] ? property['$ref'] : property['items']['$ref'] ? property['items']['$ref'] : property['x-swagger-mongoose-ref'];
   var propType = refString.match(refRegExp)[1];
   if (propType !== objectName) {
     // NOT circular reference

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-mongoose",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Generate mongoose schemas and models from swagger documents",
   "main": "./lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -7,15 +7,15 @@
     "test": "test"
   },
   "dependencies": {
-    "lodash": "^3.6.0"
+    "lodash": "^4.6.1"
   },
   "devDependencies": {
-    "async": "^1.5.0",
-    "chai": "^2.2.0",
-    "mocha": "^2.2.1",
-    "mockgoose": "^1.10.7",
-    "mongodb": "^2.0.47",
-    "mongoose": "^4.0.1"
+    "async": "^2.0.0-rc.1",
+    "chai": "^3.5.0",
+    "mocha": "^2.4.5",
+    "mockgoose": "^2.1.1",
+    "mongodb": "^2.1.11",
+    "mongoose": "^4.4.9"
   },
   "scripts": {
     "test": "mocha"

--- a/test/person.json
+++ b/test/person.json
@@ -106,6 +106,17 @@
           "items": {
             "$ref": "#/definitions/Car"
           }
+        },
+        "phone": {
+          "type": "object",
+          "properties": {
+            "home": {
+              "type": "string"
+            },
+            "mobile": {
+              "type": "string"
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
## Changes

There are 3 different use cases and 3 new custom options available for the new `x-swagger-mongoose` custom property for Swagger documents that are v2 and greater.

Custom options include: `schema-options`, `additional-properties`, and `exclude-schema`

By default the `exclude-schema` option is set to false.

Global Schema Options

``` js
x-swagger-mongoose:
  schema-options:
    timestamps: true
definitions:
  User: ...
```

Per-Schema Options

``` js
  User:
    type: object
    x-swagger-mongoose:
      schema-options:
          timestamps: true
```

Swagger Validation requires String but Schema defined as a reference

``` js
  User:
    type: object
    properties:
      otherSchema:
        type: string
        x-swagger-mongoose:
          $ref: "#/definitions/OtherSchema"
```

Additional Mongo Schema paths that are not shown in Swagger-UI Documentation

``` js
  SchemaName:
    type: object
    x-swagger-mongoose:
      additional-properties:
        user:
          $ref: "#/definitions/User"
        approved:
          type: string
          format: datetime
        rejected:
          type: string
          format: datetime
```

No Mongo Schema created for this definition

``` js
  ExcludedSchema:
    type: object
    x-swagger-mongoose:
      exclude-schema: true
```
## TODO:
- Update Test Cases to reflect the latest documentation (Don't know how long this will take as I am pretty busy but wanted to get some extra eyes on this sooner rather than later)

@simonguest - Let me know how you feel about this direction as I feel it really allows ultimate flexibility to be controlled from the swagger document itself which is kind of the whole point of this library in that the swagger document can define both the APIs and DB schema
