### PR TITLE
Version 1.0.1 - large overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .idea
+npm-debug*

--- a/README.md
+++ b/README.md
@@ -19,6 +19,30 @@ var myPet = new Pet({
 myPet.save();
 ```
 
+```js
+var swaggerMongoose = require('swagger-mongoose');
+
+var swagger = fs.readFileSync('./petstore.json');
+var Pet = swaggerMongoose.compile(swagger, { default: { timestamps: true } }).models.Pet;
+var myPet = new Pet({
+    id: 123,
+    name: 'Fluffy'
+    });
+myPet.save();
+```
+
+```js
+var swaggerMongoose = require('swagger-mongoose');
+
+var swagger = fs.readFileSync('./petstore.json');
+var Pet = swaggerMongoose.compile(swagger, { default: { timestamps: true }, MySchema: { timestamps: false } }).models.Pet;
+var myPet = new Pet({
+    id: 123,
+    name: 'Fluffy'
+    });
+myPet.save();
+```
+
 ## Installation
 
 ```js
@@ -27,7 +51,7 @@ npm install swagger-mongoose
 
 ## Limitations
 
-swagger-mongoose supports the following attributes: integer, long, float, double, string, password, boolean, date, dateTime, array (including nested schemas). swagger-mongoose also supports relationships between objects in a swagger document (thanks to @buchslava)
+swagger-mongoose supports the following attributes: integer, long, float, double, string, password, boolean, date, dateTime, object, array (including nested schemas). swagger-mongoose also supports relationships between objects in a swagger document (thanks to @buchslava)
 
 swagger-mongoose does not yet perform/create any validation from the swagger definitions (see issues if you'd like to help)
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,41 @@ Per-Schema Options
       schema-options:
           timestamps: true
 ```
+Unique Index at the property level
+```js
+  Person:
+    required:
+      - login
+    properties:
+      _id:
+        type: string
+      login:
+        type: string
+        x-swagger-mongoose:
+          index:
+            unique: 'true'
+```
+
+Compound Indexes at the document level
+```js
+definitions:
+  House:
+    x-swagger-mongoose:
+      index:
+        lng: 1
+        lat: 1
+```
+
+Unique Compound Indexes at the document level
+```js
+  User:
+    type: object
+    x-swagger-mongoose:
+      index:
+        firstName: 1
+        lastName: 1
+        unique: true
+```
 
 Swagger Validation requires String but Schema defined as a reference
 ```js
@@ -76,6 +111,37 @@ No Mongo Schema created for this definition
     type: object
     x-swagger-mongoose:
       exclude-schema: true
+```
+## Custom validators
+
+This is a bit of a work around, but in the top-level of your swagger doc:
+```js
+x-swagger-mongoose:
+  validators: ./validators
+```
+validators is a path to the validators/index.js folder/file.
+
+example validator:
+```js
+module.exports.homePhone = {
+  message: '{VALUE} is not a valid home phone number!',
+  validator: function(v){
+    return /([0-9]{1}[-\.\s])?([\(\[]?[0-9]{3}[\)\]]?[-\.\s])?([0-9]{3})[-\.\s]([0-9]{4})(?:\s?(?:x|ext)\s?([0-9])+)?/.test(v)
+  }
+}
+```
+
+at the property that you want to attach a validator for:
+```js
+phone:
+  type: object
+  properties:
+    home:
+      type: string
+      x-swagger-mongoose:
+        validator: homePhone
+    mobile:
+      type: string
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -121,8 +121,15 @@ x-swagger-mongoose:
 ```
 validators is a path to the validators/index.js folder/file.
 
+each validator is an object, that contains two properties:
+* message: this is the text displayed in the mongoose error when it returns false
+* validator: this is the function that takes one argument (I believe) and returns true or false.
+
+the properties must have these names, and must be exported in the index. unless you're aware of how to require an entire folder, in which case pull requests are welcome.
+
 example validator:
 ```js
+//  /lib/validators/index.js
 module.exports.homePhone = {
   message: '{VALUE} is not a valid home phone number!',
   validator: function(v){
@@ -131,7 +138,7 @@ module.exports.homePhone = {
 }
 ```
 
-at the property that you want to attach a validator for:
+at the property that you want to attach a validator for, add the validator property and the name of the function.
 ```js
 phone:
   type: object

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ No Mongo Schema created for this definition
 This is a bit of a work around, but in the top-level of your swagger doc:
 ```js
 x-swagger-mongoose:
-  validators: ./validators
+  validators: ./lib/validators
 ```
-validators is a path to the validators/index.js folder/file.
+validators is a relative path to the validators/index.js folder/file, FROM process.cwd().
 
 each validator is an object, that contains two properties:
 * message: this is the text displayed in the mongoose error when it returns false

--- a/README.md
+++ b/README.md
@@ -19,28 +19,63 @@ var myPet = new Pet({
 myPet.save();
 ```
 
-```js
-var swaggerMongoose = require('swagger-mongoose');
+There are 3 different use cases and 3 new custom options available for the new ```x-swagger-mongoose``` custom property for Swagger documents that are v2 and greater.
 
-var swagger = fs.readFileSync('./petstore.json');
-var Pet = swaggerMongoose.compile(swagger, { default: { timestamps: true } }).models.Pet;
-var myPet = new Pet({
-    id: 123,
-    name: 'Fluffy'
-    });
-myPet.save();
+Custom options include: ```schema-options```, ```additional-properties```, and ```exclude-schema```
+
+By default the ```exclude-schema``` option is set to false.
+
+Global Schema Options
+```js
+x-swagger-mongoose:
+  schema-options:
+    timestamps: true
+definitions:
+  User: ...
 ```
 
+Per-Schema Options
 ```js
-var swaggerMongoose = require('swagger-mongoose');
+  User:
+    type: object
+    x-swagger-mongoose:
+      schema-options:
+          timestamps: true
+```
 
-var swagger = fs.readFileSync('./petstore.json');
-var Pet = swaggerMongoose.compile(swagger, { default: { timestamps: true }, MySchema: { timestamps: false } }).models.Pet;
-var myPet = new Pet({
-    id: 123,
-    name: 'Fluffy'
-    });
-myPet.save();
+Swagger Validation requires String but Schema defined as a reference
+```js
+  User:
+    type: object
+    properties:
+      otherSchema:
+        type: string
+        x-swagger-mongoose:
+          $ref: "#/definitions/OtherSchema"
+```
+
+Additional Mongo Schema paths that are not shown in Swagger-UI Documentation
+```js
+  SchemaName:
+    type: object
+    x-swagger-mongoose:
+      additional-properties:
+        user:
+          $ref: "#/definitions/User"
+        approved:
+          type: string
+          format: datetime
+        rejected:
+          type: string
+          format: datetime
+```
+
+No Mongo Schema created for this definition
+```js
+  ExcludedSchema:
+    type: object
+    x-swagger-mongoose:
+      exclude-schema: true
 ```
 
 ## Installation

--- a/lib/index.js
+++ b/lib/index.js
@@ -168,10 +168,13 @@ var getSchema = function (objectName, fullObject) {
     else if (isPropertyHasRef(property)) {
       processRef(property, objectName, props, key, required);
     }
-    else if (property.type) {
+    else if (property.type !== 'object') {
       var type = propertyMap(property);
       props[key] = {type: type};
       fillRequired(props, key, required);
+    }
+    else if (property.type === 'object') {
+      props[key] = getSchema(key, property);
     }
     else if (isSimpleSchema(object)) {
       props = {type: propertyMap(object)};
@@ -189,7 +192,7 @@ module.exports.compileAsync = function (spec, callback) {
   }
 };
 
-module.exports.compile = function (spec, _extraDefinitions) {
+module.exports.compile = function (spec, _extraDefinitions, schemaOptions) {
   if (!spec) throw new Error('Swagger spec not supplied');
 
   var swaggerJSON = convertToJSON(spec);
@@ -199,7 +202,11 @@ module.exports.compile = function (spec, _extraDefinitions) {
   var schemas = {};
   _.forEach(definitions, function (definition, key) {
     var object = getSchema(key, definition);
-    schemas[key] = new mongoose.Schema(object);
+    var options = {};
+    if (schemaOptions) {
+      options = _.extend(options, schemaOptions.default, schemaOptions[key]);
+    }
+    schemas[key] = new mongoose.Schema(object, options);
   });
 
   var models = {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,9 @@ var Schema = mongoose.Schema;
 
 var allowedTypes = ['number','integer', 'long', 'float', 'double', 'string', 'password', 'boolean', 'date', 'dateTime', 'array'];
 var definitions = null;
+var swaggerVersion = null;
+var v2MongooseProperty = 'x-swagger-mongoose';
+var v1MongooseProperty = '_mongoose';
 
 var propertyMap = function (property) {
   switch (property.type) {
@@ -68,7 +71,7 @@ var isAllowedType = function (type) {
 };
 
 var isPropertyHasRef = function (property) {
-  return property['$ref'] || ((property['type'] == 'array') && (property['items']['$ref'])) || property['x-swagger-mongoose-ref'];
+  return property['$ref'] || ((property['type'] == 'array') && (property['items']['$ref']));
 };
 
 var fillRequired = function (object, key, template) {
@@ -80,6 +83,7 @@ var fillRequired = function (object, key, template) {
 var applyExtraDefinitions = function (definitions, _extraDefinitions) {
   if (_extraDefinitions) {
     var extraDefinitions = JSON.parse(_extraDefinitions);
+    var mongooseProperty = getMongooseProperty();
     _.each(extraDefinitions, function (val, key) {
       var s = key.split('.');
       var _definition = definitions;
@@ -90,26 +94,35 @@ var applyExtraDefinitions = function (definitions, _extraDefinitions) {
 
         _definition = _definition[s[i]];
       }
-      _definition._mongoose = val;
+      _definition[mongooseProperty] = val;
     });
   }
 };
 
+var isAtLeastSwagger2 = function() {
+  return swaggerVersion >= 2;
+};
+
+var getMongooseProperty = function() {
+  return (isAtLeastSwagger2()) ? v2MongooseProperty : v1MongooseProperty;
+};
+
 var isMongooseProperty = function (property) {
-  return !!property._mongoose;
+  return !!property[getMongooseProperty()];
 };
 
 var isMongooseArray = function (property) {
-  return property.items && property.items._mongoose;
+  return property.items && property.items[getMongooseProperty()];
 };
 
 var getMongooseSpecific = function (props, property) {
-  var mongooseSpecific = property._mongoose;
-  var ref = property.$ref;
+  var mongooseProperty = getMongooseProperty();
+  var mongooseSpecific = property[mongooseProperty];
+  var ref = (isAtLeastSwagger2() && mongooseSpecific) ? mongooseSpecific.$ref : property.$ref;
 
   if (!mongooseSpecific && isMongooseArray(property)) {
-    mongooseSpecific = property.items._mongoose;
-    ref = property.items.$ref;
+    mongooseSpecific = property.items[mongooseProperty];
+    ref = (isAtLeastSwagger2()) ? mongooseSpecific.$ref : property.items.$ref;
   }
 
   if (!mongooseSpecific) {
@@ -118,11 +131,16 @@ var getMongooseSpecific = function (props, property) {
 
   var ret = {};
 
-  if (mongooseSpecific.type === 'objectId') {
-    ret.type = Schema.Types.ObjectId;
-    if (mongooseSpecific.includeSwaggerRef !== false) {
-      ret.ref = ref.replace('#/definitions/', '');
+  if (!isAtLeastSwagger2()) {
+    if (mongooseSpecific.type === 'objectId') {
+      ret.type = Schema.Types.ObjectId;
+      if (mongooseSpecific.includeSwaggerRef !== false) {
+        ret.ref = ref.replace('#/definitions/', '');
+      }
     }
+  } else {
+    ret.type = Schema.Types.ObjectId;
+    ret.ref = ref.replace('#/definitions/', '');
   }
 
   return ret;
@@ -134,17 +152,19 @@ var isMongodbReserved = function (fieldKey) {
 
 var processRef = function (property, objectName, props, key, required) {
   var refRegExp = /^#\/definitions\/(\w*)$/;
-  var refString = property['$ref'] ? property['$ref'] : property['items']['$ref'] ? property['items']['$ref'] : property['x-swagger-mongoose-ref'];
+  var refString = property['$ref'] ? property['$ref'] : property['items']['$ref'];
   var propType = refString.match(refRegExp)[1];
   if (propType !== objectName) {
     // NOT circular reference
     props[key] = [getSchema(propType, definitions[propType]['properties'] ? definitions[propType]['properties'] : definitions[propType])];
   } else {
     // circular reference
-    props[key] = {
-      type: Schema.Types.ObjectId,
-      ref: objectName
-    };
+    if (propType) {
+      props[key] = {
+        type: Schema.Types.ObjectId,
+        ref: propType
+      };
+    }
   }
   fillRequired(props, key, required);
 };
@@ -196,6 +216,9 @@ module.exports.compile = function (spec, schemaOptions, _extraDefinitions) {
   if (!spec) throw new Error('Swagger spec not supplied');
 
   var swaggerJSON = convertToJSON(spec);
+  if (swaggerJSON.swagger) {
+    swaggerVersion = new Number(swaggerJSON.swagger);
+  }
   definitions = swaggerJSON['definitions'];
   applyExtraDefinitions(definitions, _extraDefinitions);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,8 +12,9 @@ var xSwaggerMongoose = {
   schemaOptions: {},
   additionalProperties: {},
   excludeSchema: {},
-  documentIndex: {}
+  documentIndex: {},
 };
+var validators = {};
 
 var propertyMap = function (property) {
   switch (property.type) {
@@ -147,7 +148,6 @@ var getMongooseSpecific = function (props, property) {
   }
 
   var ret = {};
-
   if (ref) {
     if (!isAtLeastSwagger2()) {
       if (mongooseSpecific.type === 'objectId') {
@@ -160,6 +160,10 @@ var getMongooseSpecific = function (props, property) {
       ret.type = Schema.Types.ObjectId;
       ret.ref = ref.replace('#/definitions/', '');
     }
+  } else if (mongooseSpecific.validator) {
+    var validator = validators[mongooseSpecific.validator];
+    ret = _.extend(ret, property, {validate: validator});
+    delete ret[mongooseProperty];
   } else {
     ret = _.extend(ret, property, mongooseSpecific);
     delete ret[mongooseProperty];
@@ -192,19 +196,42 @@ var processRef = function (property, objectName, props, key, required) {
 };
 
 var getSchema = function (objectName, fullObject) {
+
+
   var props = {};
   var required = fullObject.required || [];
   var object = fullObject['properties'] ? fullObject['properties'] : fullObject;
+  // if (objectName === 'phone') {
+  //   console.log('objectName: '+objectName);
+  //   console.log(object)
+  // }
 
   _.forEach(object, function (property, key) {
     var schemaProperty = getSchemaProperty(property, key, required, objectName, object);
+    // if (objectName === 'phone') {
+    //   console.log(schemaProperty)
+    // }
     props = _.extend(props, schemaProperty);
   });
 
   return props;
 };
 
+var hasValidator = function(property){
+  if (property.validator) {
+      return true;
+  } else {
+      return false;
+  }
+
+}
+
 var getSchemaProperty = function(property, key, required, objectName, object) {
+  // if (key === 'home') {
+  //   console.log('objectName: '+objectName);
+  //   console.log(property)
+  // }
+
   var props = {};
   if (isMongodbReserved(key) === true) {
     return;
@@ -253,6 +280,7 @@ var processDocumentIndex = function(schema, index){
 
 };
 
+
 module.exports.compileAsync = function (spec, callback) {
   try {
     callback(null, this.compile(spec));
@@ -267,7 +295,11 @@ module.exports.compile = function (spec, _extraDefinitions) {
   if (swaggerJSON.swagger) {
     swaggerVersion = new Number(swaggerJSON.swagger);
   }
+
+
+
   definitions = swaggerJSON['definitions'];
+
   applyExtraDefinitions(definitions, _extraDefinitions);
 
   var customMongooseProperty = getMongooseProperty();
@@ -278,7 +310,6 @@ module.exports.compile = function (spec, _extraDefinitions) {
 
   var schemas = {};
   _.forEach(definitions, function (definition, key) {
-
     var object = null;
     var options = xSwaggerMongoose.schemaOptions;
     var excludedSchema = xSwaggerMongoose.excludeSchema;
@@ -316,7 +347,6 @@ module.exports.compile = function (spec, _extraDefinitions) {
 };
 
 var processMongooseDefinition = function(key, customOptions) {
-
   if (customOptions) {
     if (customOptions['schema-options']) {
       xSwaggerMongoose.schemaOptions[key] = customOptions['schema-options'];
@@ -329,6 +359,14 @@ var processMongooseDefinition = function(key, customOptions) {
     }
     if (customOptions['index']) {
       xSwaggerMongoose.documentIndex[key] = customOptions['index'];
+    }
+    if (customOptions['validator']) {
+      console.log('got a validator: '+key);
+      console.log(customOptions['validator']);
+      xSwaggerMongoose.validator[key] = customOptions['validator'];
+    }
+    if (customOptions['validators']) {
+      validators = require(customOptions['validators'])
     }
 
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -304,8 +304,8 @@ module.exports.compile = function (spec, _extraDefinitions) {
 };
 
 var processMongooseDefinition = function(key, customOptions) {
-  console.log('Key:'+key)
-  console.log(customOptions);
+  // console.log('Key:'+key)
+  // console.log(customOptions);
   if (customOptions) {
     if (customOptions['schema-options']) {
       xSwaggerMongoose.schemaOptions[key] = customOptions['schema-options'];

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,8 @@ var v1MongooseProperty = '_mongoose';
 var xSwaggerMongoose = {
   schemaOptions: {},
   additionalProperties: {},
-  excludeSchema: {}
+  excludeSchema: {},
+  documentIndex: {}
 };
 
 var propertyMap = function (property) {
@@ -112,16 +113,6 @@ var applyExtraDefinitions = function (definitions, _extraDefinitions) {
       definitions[key][mongooseProperty] = val
     });
 
-      // NOTE: We don't need this anymore. lets get rid of person.mongoose.json syntax and just rely on swagger spec.
-      // for (var i = 0; i < s.length; i++) {
-      //   if (!_definition[s[i]]) {
-      //     throw new Error('Wrong path: ' + key);
-      //   }
-      //
-      //   _definition = _definition[s[i]];
-      // }
-      //
-      // _definition[mongooseProperty] = val;
   }
 };
 
@@ -244,6 +235,24 @@ var getSchemaProperty = function(property, key, required, objectName, object) {
   return props;
 };
 
+var processDocumentIndex = function(schema, index){
+  //TODO: check indicies are numbers
+  var isUniqueIndex = false;
+  if (_.isEmpty(index)) {
+    return;
+  }
+  if (index.unique) {
+    isUniqueIndex = true;
+  }
+  delete index.unique;
+  if (isUniqueIndex) {
+    schema.index(index, {unique:true})
+  } else {
+    schema.index(index)
+  }
+
+};
+
 module.exports.compileAsync = function (spec, callback) {
   try {
     callback(null, this.compile(spec));
@@ -273,6 +282,7 @@ module.exports.compile = function (spec, _extraDefinitions) {
     var object = null;
     var options = xSwaggerMongoose.schemaOptions;
     var excludedSchema = xSwaggerMongoose.excludeSchema;
+    var documentIndex = xSwaggerMongoose.documentIndex[key];
 
     if (definition[customMongooseProperty]) {
       processMongooseDefinition(key, definition[customMongooseProperty]);
@@ -288,7 +298,9 @@ module.exports.compile = function (spec, _extraDefinitions) {
       var additionalProperties = _.extend({}, xSwaggerMongoose.additionalProperties[customMongooseProperty], xSwaggerMongoose.additionalProperties[key]);
       additionalProperties = processAdditionalProperties(additionalProperties, key)
       object = _.extend(object, additionalProperties);
-      schemas[key] = new mongoose.Schema(object, options);
+      var schema = new mongoose.Schema(object, options);
+      processDocumentIndex(schema, documentIndex)
+      schemas[key] = schema
     }
   });
 
@@ -304,8 +316,7 @@ module.exports.compile = function (spec, _extraDefinitions) {
 };
 
 var processMongooseDefinition = function(key, customOptions) {
-  // console.log('Key:'+key)
-  // console.log(customOptions);
+
   if (customOptions) {
     if (customOptions['schema-options']) {
       xSwaggerMongoose.schemaOptions[key] = customOptions['schema-options'];
@@ -316,6 +327,10 @@ var processMongooseDefinition = function(key, customOptions) {
     if (customOptions['additional-properties']) {
       xSwaggerMongoose.additionalProperties[key] = customOptions['additional-properties'];
     }
+    if (customOptions['index']) {
+      xSwaggerMongoose.documentIndex[key] = customOptions['index'];
+    }
+
   }
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -184,15 +184,15 @@ var getSchema = function (objectName, fullObject) {
   return props;
 };
 
-module.exports.compileAsync = function (spec, callback) {
+module.exports.compileAsync = function (spec, schemaOptions, callback) {
   try {
-    callback(null, this.compile(spec));
+    callback(null, this.compile(spec, schemaOptions));
   } catch (err) {
     callback({message: err}, null);
   }
 };
 
-module.exports.compile = function (spec, _extraDefinitions, schemaOptions) {
+module.exports.compile = function (spec, schemaOptions, _extraDefinitions) {
   if (!spec) throw new Error('Swagger spec not supplied');
 
   var swaggerJSON = convertToJSON(spec);

--- a/lib/index.js
+++ b/lib/index.js
@@ -151,7 +151,8 @@ var getMongooseSpecific = function (props, property) {
       ret.ref = ref.replace('#/definitions/', '');
     }
   } else {
-    ret = _.extend(ret, mongooseSpecific);
+    ret = _.extend(ret, property, mongooseSpecific);
+    delete ret[mongooseProperty];
   }
 
   return ret;
@@ -260,7 +261,7 @@ module.exports.compile = function (spec, _extraDefinitions) {
     }
     object = getSchema(key, definition);
     if (options) {
-      options = _.extend(options[customMongooseProperty], options[key]);
+      options = _.extend({}, options[customMongooseProperty], options[key]);
     }
     if (typeof excludedSchema === 'object') {
       excludedSchema = excludedSchema[customMongooseProperty] || excludedSchema[key];

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@
 var _ = require('lodash');
 var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
+var path = require('path');
 
 var allowedTypes = ['number','integer', 'long', 'float', 'double', 'string', 'password', 'boolean', 'date', 'dateTime', 'array'];
 var definitions = null;
@@ -345,7 +346,8 @@ var processMongooseDefinition = function(key, customOptions) {
       xSwaggerMongoose.documentIndex[key] = customOptions['index'];
     }
     if (customOptions['validators']) {
-      validators = require(customOptions['validators'])
+      var validatorsDirectory = path.resolve(process.cwd(),customOptions['validators'])
+      validators = require(validatorsDirectory)
     }
 
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -89,20 +89,39 @@ var fillRequired = function (object, key, template) {
 
 var applyExtraDefinitions = function (definitions, _extraDefinitions) {
   if (_extraDefinitions) {
-    var extraDefinitions = JSON.parse(_extraDefinitions);
-    var mongooseProperty = getMongooseProperty();
-    _.each(extraDefinitions, function (val, key) {
-      var s = key.split('.');
-      var _definition = definitions;
-      for (var i = 0; i < s.length; i++) {
-        if (!_definition[s[i]]) {
-          throw new Error('Wrong path: ' + key);
-        }
 
-        _definition = _definition[s[i]];
-      }
-      _definition[mongooseProperty] = val;
+    //TODO: check for string or object assume object for now.
+    // var extraDefinitions = JSON.parse(_extraDefinitions);
+    var mongooseProperty = getMongooseProperty();
+
+    //remove default object from extra, we're going to handle that seperately
+    var defaultDefs;
+    if (!_extraDefinitions.default) {
+      defaultDefs = null;
+    } else {
+      defaultDefs = _extraDefinitions.default
+      delete _extraDefinitions.default;
+      _.each(definitions, function (val,key){
+        //lets add that default to everything.
+        val[mongooseProperty] = defaultDefs
+      });
+    }
+
+    var extraDefinitions = _extraDefinitions;
+    _.each(extraDefinitions, function (val, key) {
+      definitions[key][mongooseProperty] = val
     });
+
+      // NOTE: We don't need this anymore. lets get rid of person.mongoose.json syntax and just rely on swagger spec.
+      // for (var i = 0; i < s.length; i++) {
+      //   if (!_definition[s[i]]) {
+      //     throw new Error('Wrong path: ' + key);
+      //   }
+      //
+      //   _definition = _definition[s[i]];
+      // }
+      //
+      // _definition[mongooseProperty] = val;
   }
 };
 
@@ -235,7 +254,6 @@ module.exports.compileAsync = function (spec, callback) {
 
 module.exports.compile = function (spec, _extraDefinitions) {
   if (!spec) throw new Error('Swagger spec not supplied');
-
   var swaggerJSON = convertToJSON(spec);
   if (swaggerJSON.swagger) {
     swaggerVersion = new Number(swaggerJSON.swagger);
@@ -286,6 +304,8 @@ module.exports.compile = function (spec, _extraDefinitions) {
 };
 
 var processMongooseDefinition = function(key, customOptions) {
+  console.log('Key:'+key)
+  console.log(customOptions);
   if (customOptions) {
     if (customOptions['schema-options']) {
       xSwaggerMongoose.schemaOptions[key] = customOptions['schema-options'];

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,11 @@ var definitions = null;
 var swaggerVersion = null;
 var v2MongooseProperty = 'x-swagger-mongoose';
 var v1MongooseProperty = '_mongoose';
+var xSwaggerMongoose = {
+  schemaOptions: {},
+  additionalProperties: {},
+  excludeSchema: {}
+};
 
 var propertyMap = function (property) {
   switch (property.type) {
@@ -75,8 +80,10 @@ var isPropertyHasRef = function (property) {
 };
 
 var fillRequired = function (object, key, template) {
-  if (template.indexOf(key) >= 0) {
+  if (template && Array.isArray(template) && template.indexOf(key) >= 0) {
     object[key].required = true;
+  } else if (typeof template === 'boolean') {
+    object[key].required = template;
   }
 };
 
@@ -139,6 +146,7 @@ var getMongooseSpecific = function (props, property) {
       }
     }
   } else {
+
     ret.type = Schema.Types.ObjectId;
     ret.ref = ref.replace('#/definitions/', '');
   }
@@ -175,44 +183,53 @@ var getSchema = function (objectName, fullObject) {
   var object = fullObject['properties'] ? fullObject['properties'] : fullObject;
 
   _.forEach(object, function (property, key) {
-    if (isMongodbReserved(key) === true) {
-      return;
-    }
-
-    if (isMongooseProperty(property)) {
-      props[key] = getMongooseSpecific(props, property);
-    }
-    else if (isMongooseArray(property)) {
-      props[key] = [getMongooseSpecific(props, property)];
-    }
-    else if (isPropertyHasRef(property)) {
-      processRef(property, objectName, props, key, required);
-    }
-    else if (property.type !== 'object') {
-      var type = propertyMap(property);
-      props[key] = {type: type};
-      fillRequired(props, key, required);
-    }
-    else if (property.type === 'object') {
-      props[key] = getSchema(key, property);
-    }
-    else if (isSimpleSchema(object)) {
-      props = {type: propertyMap(object)};
-    }
+    var schemaProperty = getSchemaProperty(property, key, required, objectName, object);
+    props = _.extend(props, schemaProperty);
   });
 
   return props;
 };
 
-module.exports.compileAsync = function (spec, schemaOptions, callback) {
+var getSchemaProperty = function(property, key, required, objectName, object) {
+  var props = {};
+  if (isMongodbReserved(key) === true) {
+    return;
+  }
+
+  if (isMongooseProperty(property)) {
+    props[key] = getMongooseSpecific(props, property);
+  }
+  else if (isMongooseArray(property)) {
+    props[key] = [getMongooseSpecific(props, property)];
+  }
+  else if (isPropertyHasRef(property)) {
+    processRef(property, objectName, props, key, required);
+  }
+  else if (property.type !== 'object') {
+    var type = propertyMap(property);
+    props[key] = {type: type};
+  }
+  else if (property.type === 'object') {
+    props[key] = getSchema(key, property);
+  }
+  else if (isSimpleSchema(object)) {
+    props = {type: propertyMap(object)};
+  }
+  if (required) {
+    fillRequired(props, key, required);
+  }
+  return props;
+};
+
+module.exports.compileAsync = function (spec, callback) {
   try {
-    callback(null, this.compile(spec, schemaOptions));
+    callback(null, this.compile(spec));
   } catch (err) {
     callback({message: err}, null);
   }
 };
 
-module.exports.compile = function (spec, schemaOptions, _extraDefinitions) {
+module.exports.compile = function (spec, _extraDefinitions) {
   if (!spec) throw new Error('Swagger spec not supplied');
 
   var swaggerJSON = convertToJSON(spec);
@@ -222,14 +239,35 @@ module.exports.compile = function (spec, schemaOptions, _extraDefinitions) {
   definitions = swaggerJSON['definitions'];
   applyExtraDefinitions(definitions, _extraDefinitions);
 
+  var customMongooseProperty = getMongooseProperty();
+
+  if (swaggerJSON[customMongooseProperty]) {
+    processMongooseDefinition(customMongooseProperty, swaggerJSON[customMongooseProperty]);
+  }
+
   var schemas = {};
   _.forEach(definitions, function (definition, key) {
-    var object = getSchema(key, definition);
-    var options = {};
-    if (schemaOptions) {
-      options = _.extend(options, schemaOptions.default, schemaOptions[key]);
+
+    var object = null;
+    var options = xSwaggerMongoose.schemaOptions;
+    var excludedSchema = xSwaggerMongoose.excludeSchema;
+
+    if (definition[customMongooseProperty]) {
+      processMongooseDefinition(key, definition[customMongooseProperty]);
     }
-    schemas[key] = new mongoose.Schema(object, options);
+    object = getSchema(key, definition);
+    if (options) {
+      options = _.extend(options[customMongooseProperty], options[key]);
+    }
+    if (typeof excludedSchema === 'object') {
+      excludedSchema = excludedSchema[customMongooseProperty] || excludedSchema[key];
+    }
+    if (object && !excludedSchema) {
+      var additionalProperties = _.extend({}, xSwaggerMongoose.additionalProperties[customMongooseProperty], xSwaggerMongoose.additionalProperties[key]);
+      additionalProperties = processAdditionalProperties(additionalProperties, key)
+      object = _.extend(object, additionalProperties);
+      schemas[key] = new mongoose.Schema(object, options);
+    }
   });
 
   var models = {};
@@ -241,4 +279,29 @@ module.exports.compile = function (spec, schemaOptions, _extraDefinitions) {
     schemas: schemas,
     models: models
   };
+};
+
+var processMongooseDefinition = function(key, customOptions) {
+  if (customOptions) {
+    if (customOptions['schema-options']) {
+      xSwaggerMongoose.schemaOptions[key] = customOptions['schema-options'];
+    }
+    if (customOptions['exclude-schema']) {
+      xSwaggerMongoose.excludeSchema[key] = customOptions['exclude-schema'];
+    }
+    if (customOptions['additional-properties']) {
+      xSwaggerMongoose.additionalProperties[key] = customOptions['additional-properties'];
+    }
+  }
+};
+
+var processAdditionalProperties = function(additionalProperties, objectName) {
+  var props = {};
+  var customMongooseProperty = getMongooseProperty();
+  _.each(additionalProperties, function (property, key) {
+    var modifiedProperty = {};
+    modifiedProperty[customMongooseProperty] = property;
+    props = _.extend(props, getSchemaProperty(modifiedProperty, key, property.required, objectName));
+  });
+  return props;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -208,7 +208,7 @@ var getSchema = function (objectName, fullObject) {
 
   _.forEach(object, function (property, key) {
     var schemaProperty = getSchemaProperty(property, key, required, objectName, object);
-    // if (objectName === 'phone') {
+    // if (objectName === 'Car') {
     //   console.log(schemaProperty)
     // }
     props = _.extend(props, schemaProperty);
@@ -217,17 +217,8 @@ var getSchema = function (objectName, fullObject) {
   return props;
 };
 
-var hasValidator = function(property){
-  if (property.validator) {
-      return true;
-  } else {
-      return false;
-  }
-
-}
-
 var getSchemaProperty = function(property, key, required, objectName, object) {
-  // if (key === 'home') {
+  // if (key === 'provider') {
   //   console.log('objectName: '+objectName);
   //   console.log(property)
   // }
@@ -248,7 +239,12 @@ var getSchemaProperty = function(property, key, required, objectName, object) {
   }
   else if (property.type !== 'object') {
     var type = propertyMap(property);
-    props[key] = {type: type};
+    if (property.enum && _.isArray(property.enum)) {
+      props[key] = {type: type, enum: property.enum};
+    } else {
+      props[key] = {type: type};
+    }
+
   }
   else if (property.type === 'object') {
     props[key] = getSchema(key, property);

--- a/lib/index.js
+++ b/lib/index.js
@@ -138,17 +138,20 @@ var getMongooseSpecific = function (props, property) {
 
   var ret = {};
 
-  if (!isAtLeastSwagger2()) {
-    if (mongooseSpecific.type === 'objectId') {
-      ret.type = Schema.Types.ObjectId;
-      if (mongooseSpecific.includeSwaggerRef !== false) {
-        ret.ref = ref.replace('#/definitions/', '');
+  if (ref) {
+    if (!isAtLeastSwagger2()) {
+      if (mongooseSpecific.type === 'objectId') {
+        ret.type = Schema.Types.ObjectId;
+        if (mongooseSpecific.includeSwaggerRef !== false) {
+          ret.ref = ref.replace('#/definitions/', '');
+        }
       }
+    } else {
+      ret.type = Schema.Types.ObjectId;
+      ret.ref = ref.replace('#/definitions/', '');
     }
   } else {
-
-    ret.type = Schema.Types.ObjectId;
-    ret.ref = ref.replace('#/definitions/', '');
+    ret = _.extend(ret, mongooseSpecific);
   }
 
   return ret;

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,7 +68,7 @@ var isAllowedType = function (type) {
 };
 
 var isPropertyHasRef = function (property) {
-  return property['$ref'] || ((property['type'] == 'array') && (property['items']['$ref']));
+  return property['$ref'] || ((property['type'] == 'array') && (property['items']['$ref'])) || property['x-swagger-mongoose-ref'];
 };
 
 var fillRequired = function (object, key, template) {
@@ -134,7 +134,7 @@ var isMongodbReserved = function (fieldKey) {
 
 var processRef = function (property, objectName, props, key, required) {
   var refRegExp = /^#\/definitions\/(\w*)$/;
-  var refString = property['$ref'] ? property['$ref'] : property['items']['$ref'];
+  var refString = property['$ref'] ? property['$ref'] : property['items']['$ref'] ? property['items']['$ref'] : property['x-swagger-mongoose-ref'];
   var propType = refString.match(refRegExp)[1];
   if (propType !== objectName) {
     // NOT circular reference

--- a/lib/index.js
+++ b/lib/index.js
@@ -201,16 +201,9 @@ var getSchema = function (objectName, fullObject) {
   var props = {};
   var required = fullObject.required || [];
   var object = fullObject['properties'] ? fullObject['properties'] : fullObject;
-  // if (objectName === 'phone') {
-  //   console.log('objectName: '+objectName);
-  //   console.log(object)
-  // }
 
   _.forEach(object, function (property, key) {
     var schemaProperty = getSchemaProperty(property, key, required, objectName, object);
-    // if (objectName === 'Car') {
-    //   console.log(schemaProperty)
-    // }
     props = _.extend(props, schemaProperty);
   });
 
@@ -218,11 +211,6 @@ var getSchema = function (objectName, fullObject) {
 };
 
 var getSchemaProperty = function(property, key, required, objectName, object) {
-  // if (key === 'provider') {
-  //   console.log('objectName: '+objectName);
-  //   console.log(property)
-  // }
-
   var props = {};
   if (isMongodbReserved(key) === true) {
     return;
@@ -355,11 +343,6 @@ var processMongooseDefinition = function(key, customOptions) {
     }
     if (customOptions['index']) {
       xSwaggerMongoose.documentIndex[key] = customOptions['index'];
-    }
-    if (customOptions['validator']) {
-      console.log('got a validator: '+key);
-      console.log(customOptions['validator']);
-      xSwaggerMongoose.validator[key] = customOptions['validator'];
     }
     if (customOptions['validators']) {
       validators = require(customOptions['validators'])

--- a/lib/validators/index.js
+++ b/lib/validators/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports.homePhone = {
+  message: '{VALUE} is not a valid home phone number!',
+  validator: function(v){
+    return /([0-9]{1}[-\.\s])?([\(\[]?[0-9]{3}[\)\]]?[-\.\s])?([0-9]{3})[-\.\s]([0-9]{4})(?:\s?(?:x|ext)\s?([0-9])+)?/.test(v)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/simonguest/swagger-mongoose"
+    "url": "https://github.com/paul42/swagger-mongoose"
   },
   "keywords": [
     "swagger",
@@ -30,10 +30,10 @@
     "mongo",
     "schema"
   ],
-  "author": "Simon Guest <me@simonguest.com> (http://github.com/simonguest)",
+  "author": "Paul.42 <paul.42@gmail.com> (http://github.com/paul42)",
   "license": "Apache 2",
   "bugs": {
-    "url": "https://github.com/simonguest/swagger-mongoose/issues"
+    "url": "https://github.com/paul42/swagger-mongoose/issues"
   },
-  "homepage": "https://github.com/simonguest/swagger-mongoose"
+  "homepage": "https://github.com/paul42/swagger-mongoose"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-mongoose-fork",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Generate mongoose schemas and models from swagger documents",
   "main": "./lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "async": "^2.0.0-rc.1",
     "chai": "^3.5.0",
     "mocha": "^2.4.5",
-    "mockgoose": "^2.1.1",
+    "mockgoose": "^6.0.0",
     "mongodb": "^2.1.11",
     "mongoose": "^4.4.9"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-mongoose",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Generate mongoose schemas and models from swagger documents",
   "main": "./lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -7,15 +7,15 @@
     "test": "test"
   },
   "dependencies": {
-    "lodash": "^3.6.0"
+    "lodash": "^4.6.1"
   },
   "devDependencies": {
-    "async": "^1.5.0",
-    "chai": "^2.2.0",
-    "mocha": "^2.2.1",
-    "mockgoose": "^1.10.7",
-    "mongodb": "^2.0.47",
-    "mongoose": "^4.0.1"
+    "async": "^2.0.0-rc.1",
+    "chai": "^3.5.0",
+    "mocha": "^2.4.5",
+    "mockgoose": "^2.1.1",
+    "mongodb": "^2.1.11",
+    "mongoose": "^4.4.9"
   },
   "scripts": {
     "test": "mocha"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-mongoose",
-  "version": "0.1.4",
+  "version": "1.0.0",
   "description": "Generate mongoose schemas and models from swagger documents",
   "main": "./lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-mongoose-fork",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Generate mongoose schemas and models from swagger documents",
   "main": "./lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "swagger-mongoose",
+  "name": "swagger-mongoose-fork",
   "version": "1.0.0",
   "description": "Generate mongoose schemas and models from swagger documents",
   "main": "./lib/index.js",

--- a/test/index.js
+++ b/test/index.js
@@ -134,10 +134,6 @@ describe('swagger-mongoose tests', function () {
     var House = models.House;
     var Car = models.Car;
     assert(Person.schema.paths.cars.options.type[0].type === Schema.Types.ObjectId, 'Wrong "car" type');
-
-    // assert(Person.schema.paths.cars.options.type[0].ref === undefined, 'Ref to "car" should be undefined');
-    //TODO: I don't know the purpose of the exclude schema, but it was in person.mongoose.json
-
     assert(Person.schema.paths.houses.options.type[0].type === Schema.Types.ObjectId, 'Wrong "house" type');
     assert(Person.schema.paths.houses.options.type[0].ref === 'House', 'Ref to "house" should be "House"');
 

--- a/test/index.js
+++ b/test/index.js
@@ -244,9 +244,35 @@ describe('swagger-mongoose tests', function () {
             done();
           }
         })
-
       })
+    });
 
+  it('should identify and throw errors on compound indices marked unique', function (done) {
+      var swagger = fs.readFileSync('./test/person.json');
+      var models = swaggerMongoose.compile(swagger.toString()).models;
+      var Human = models.Human;
+      var human = new Human({
+        firstName: 'James',
+        lastName: 'Bond'
+      })
+      human.save(function(err,data){
+        var copyCat = new Human({
+          firstName: 'James',
+          lastName: 'Bond'
+        })
+        copyCat.save(function(err,data){
+          if (err) {
+            assert.equal(err.name, 'MongoError');
+            assert.include(err.errmsg, 'duplicate key')
+            assert.include(err.errmsg, 'firstName')
+            assert.include(err.errmsg, 'lastName')
+            done();
+          } else {
+            assert.ok(data);
+            done();
+          }
+        })
+      })
 
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -213,6 +213,20 @@ describe('swagger-mongoose tests', function () {
     });
   });
 
+  it('should identify return indicies from the swagger document', function (done) {
+      var swagger = fs.readFileSync('./test/person.json');
+      var models = swaggerMongoose.compile(swagger.toString()).models;
+      var Human = models.Human;
+      var Person = models.Person;
+      var House = models.House;
+      assert.propertyVal(Person.schema.paths.login._index, 'unique', 'true', 'Person.login should have a unique index')
+      assert.sameDeepMembers(Human.schema._indexes[0], [ { firstName: 1, lastName: 1 },{ unique: true, background: true } ], 'Human document should have an object of firstName/lastName, and a unique:true object');
+      assert.sameDeepMembers(House.schema._indexes[0], [ { lng: 1, lat: 1 }, { background: true } ], 'House document should have an object of lng/lat, but not a unique key');
+
+      done();
+
+    });
+
   it('should identify and throw errors on duplicate properties marked unique', function (done) {
       var swagger = fs.readFileSync('./test/person.json');
       var models = swaggerMongoose.compile(swagger.toString()).models;

--- a/test/index.js
+++ b/test/index.js
@@ -328,7 +328,7 @@ describe('swagger-mongoose tests', function () {
       })
     });
 
-  it('should identify and add enum to strings', function (done) {
+  it('should identify and add enum to schema', function (done) {
       var swagger = fs.readFileSync('./test/person.json');
       var models = swaggerMongoose.compile(swagger.toString()).models;
       var Car = models.Car;

--- a/test/index.js
+++ b/test/index.js
@@ -134,6 +134,7 @@ describe('swagger-mongoose tests', function () {
     });
   });
 
+
   it('should create an example person with relations to external collections', function (done) {
     var swagger = fs.readFileSync('./test/person.json');
 
@@ -286,7 +287,6 @@ describe('swagger-mongoose tests', function () {
         })
         copyCat.save(function(err,data){
           if (err) {
-            console.log(err);
             assert.equal(err.name, 'MongoError');
             assert.include(err.errmsg, 'duplicate key')
             assert.include(err.errmsg, '{ : "James", : "Bond" }')
@@ -323,6 +323,29 @@ describe('swagger-mongoose tests', function () {
           done();
         } else {
           assert.fail('phone validator should have prevented this')
+          done();
+        }
+      })
+    });
+
+  it('should identify and add enum to strings', function (done) {
+      var swagger = fs.readFileSync('./test/person.json');
+      var models = swaggerMongoose.compile(swagger.toString()).models;
+      var Car = models.Car;
+
+      var car = new Car({
+        provider: 'Soviet Motors',
+        model: 'Gremlin'
+      });
+
+      car.save(function(err,data){
+        if(err){
+          var expectedErrorMessage = _.get(err, 'errors.provider.message');
+          assert.equal(err.name, 'ValidationError');
+          assert.include(expectedErrorMessage, 'is not a valid enum value')
+          done();
+        } else {
+          assert.fail('enum for car should have prevented this')
           done();
         }
       })

--- a/test/index.js
+++ b/test/index.js
@@ -134,7 +134,6 @@ describe('swagger-mongoose tests', function () {
     });
   });
 
-
   it('should create an example person with relations to external collections', function (done) {
     var swagger = fs.readFileSync('./test/person.json');
 

--- a/test/index.js
+++ b/test/index.js
@@ -213,6 +213,43 @@ describe('swagger-mongoose tests', function () {
     });
   });
 
+  it('should identify and throw errors on duplicate properties marked unique', function (done) {
+      var swagger = fs.readFileSync('./test/person.json');
+      var models = swaggerMongoose.compile(swagger.toString()).models;
+      var Person = models.Person;
+
+      var person = new Person({
+        login: 'jb@mi6.gov',
+        firstName: 'James',
+        lastName: 'Bond',
+        phone: {
+          home: "(123) 456-7890",
+          mobile: "(012) 345-6789"
+        }
+      });
+      person.save(function(err,data){
+        var copyCat = new Person({
+          login: 'jb@mi6.gov',
+          firstName: 'Jake',
+          lastName: 'Barrington',
+        });
+        copyCat.save(function(err,data){
+          if(err){
+            assert.equal(err.name, 'MongoError');
+            assert.include(err.errmsg, 'duplicate key')
+            assert.include(err.errmsg, 'login')
+            done();
+          } else {
+            asset.fail('unique index should have prevented this')
+            done();
+          }
+        })
+
+      })
+
+
+    });
+
   it('should create an example pet from a JSON object with default schema options', function (done) {
     var swagger = fs.readFileSync('./test/petstore.json');
 

--- a/test/person.json
+++ b/test/person.json
@@ -50,6 +50,12 @@
     },
     "definitions": {
         "House": {
+            "x-swagger-mongoose":{
+              "index":{
+                "lng":1,
+                "lat":1
+              }
+            },
             "required": [
                 "lng",
                 "lat"

--- a/test/person.json
+++ b/test/person.json
@@ -17,7 +17,8 @@
         "http"
     ],
     "x-swagger-mongoose": {
-        "validators": "./validators"
+        "validators": "./lib/validators",
+        "description":"The relative path to validators library from process.cwd()"
     },
     "paths": {
         "/persons": {

--- a/test/person.json
+++ b/test/person.json
@@ -16,6 +16,9 @@
     "schemes": [
         "http"
     ],
+    "x-swagger-mongoose": {
+        "validators": "./validators"
+    },
     "paths": {
         "/persons": {
             "get": {
@@ -50,11 +53,11 @@
     },
     "definitions": {
         "House": {
-            "x-swagger-mongoose":{
-              "index":{
-                "lng":1,
-                "lat":1
-              }
+            "x-swagger-mongoose": {
+                "index": {
+                    "lng": 1,
+                    "lat": 1
+                }
             },
             "required": [
                 "lng",
@@ -97,9 +100,9 @@
                 "login": {
                     "type": "string",
                     "x-swagger-mongoose": {
-                      "index": {
-                        "unique":"true"
-                      }
+                        "index": {
+                            "unique": "true"
+                        }
                     }
                 },
                 "firstName": {
@@ -130,7 +133,10 @@
                     "type": "object",
                     "properties": {
                         "home": {
-                            "type": "string"
+                            "type": "string",
+                            "x-swagger-mongoose": {
+                                "validator": "homePhone"
+                            }
                         },
                         "mobile": {
                             "type": "string"
@@ -140,12 +146,12 @@
             }
         },
         "Human": {
-            "x-swagger-mongoose":{
-              "index":{
-                "firstName":1,
-                "lastName":1,
-                "unique":"true"
-              }
+            "x-swagger-mongoose": {
+                "index": {
+                    "firstName": 1,
+                    "lastName": 1,
+                    "unique": "true"
+                }
             },
             "properties": {
                 "firstName": {

--- a/test/person.json
+++ b/test/person.json
@@ -1,155 +1,164 @@
 {
-  "swagger": "2.0",
-  "info": {
-    "version": "1.0.0",
-    "title": "Persons",
-    "contact": {
-      "name": "Vyacheslav Chub",
-      "email": "vyacheslav.chub@gmail.com"
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Persons",
+        "contact": {
+            "name": "Vyacheslav Chub",
+            "email": "vyacheslav.chub@gmail.com"
+        },
+        "license": {
+            "name": "The MIT License (MIT)",
+            "url": "https://opensource.org/licenses/MIT"
+        }
     },
-    "license": {
-      "name": "The MIT License (MIT)",
-      "url": "https://opensource.org/licenses/MIT"
-    }
-  },
-  "basePath": "/api",
-  "schemes": [
-    "http"
-  ],
-  "paths": {
-    "/persons": {
-      "get": {
-        "tags": ["Person Operations"],
-        "summary": "finds persons in the system",
-        "responses": {
-          "200": {
-            "description": "person response",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Person"
-              }
-            },
-            "headers": {
-              "x-expires": {
-                "type": "string"
-              }
+    "basePath": "/api",
+    "schemes": [
+        "http"
+    ],
+    "paths": {
+        "/persons": {
+            "get": {
+                "tags": [
+                    "Person Operations"
+                ],
+                "summary": "finds persons in the system",
+                "responses": {
+                    "200": {
+                        "description": "person response",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Person"
+                            }
+                        },
+                        "headers": {
+                            "x-expires": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
             }
-          },
-          "default": {
-            "description": "unexpected error",
-            "schema": {
-              "$ref": "#/definitions/Error"
+        }
+    },
+    "definitions": {
+        "House": {
+            "required": [
+                "lng",
+                "lat"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "lng": {
+                    "type": "double"
+                },
+                "lat": {
+                    "type": "double"
+                }
             }
-          }
-        }
-      }
-    }
-  },
-  "definitions": {
-    "House": {
-      "required": [
-        "lng",
-        "lat"
-      ],
-      "properties": {
-        "description": {
-          "type": "string"
         },
-        "lng": {
-          "type": "double"
-        },
-        "lat": {
-          "type": "double"
-        }
-      }
-    },
-    "Car": {
-      "required": [
-        "provider",
-        "model"
-      ],
-      "properties": {
-        "provider": {
-          "type": "string"
-        },
-        "model": {
-          "type": "string"
-        }
-      }
-    },
-    "Person": {
-      "required": [
-        "login"
-      ],
-      "properties": {
-        "_id": {
-          "type": "string"
-        },
-        "login": {
-          "type": "string"
-        },
-        "firstName": {
-          "type": "string"
-        },
-        "lastName": {
-          "type": "string"
-        },
-        "houses": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/House"
-          }
-        },
-        "cars": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Car"
-          }
-        },
-        "phone": {
-          "type": "object",
-          "properties": {
-            "home": {
-              "type": "string"
-            },
-            "mobile": {
-              "type": "string"
+        "Car": {
+            "required": [
+                "provider",
+                "model"
+            ],
+            "properties": {
+                "provider": {
+                    "type": "string"
+                },
+                "model": {
+                    "type": "string"
+                }
             }
-          }
+        },
+        "Person": {
+            "required": [
+                "login"
+            ],
+            "properties": {
+                "_id": {
+                    "type": "string"
+                },
+                "login": {
+                    "type": "string"
+                },
+                "firstName": {
+                    "type": "string"
+                },
+                "lastName": {
+                    "type": "string"
+                },
+                "houses": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-swagger-mongoose": {
+                            "$ref": "#/definitions/House"
+                        }
+                    }
+                },
+                "cars": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "x-swagger-mongoose": {
+                            "$ref": "#/definitions/Car",
+                            "exclude-schema": true
+                        }
+                    }
+                },
+                "phone": {
+                    "type": "object",
+                    "properties": {
+                        "home": {
+                            "type": "string"
+                        },
+                        "mobile": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "Human": {
+            "properties": {
+                "firstName": {
+                    "type": "string"
+                },
+                "lastName": {
+                    "type": "string"
+                },
+                "father": {
+                    "$ref": "#/definitions/Human"
+                },
+                "mother": {
+                    "$ref": "#/definitions/Human"
+                }
+            }
+        },
+        "Error": {
+            "required": [
+                "code",
+                "message"
+            ],
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
         }
-      }
-    },
-    "Human": {
-      "properties": {
-        "firstName": {
-          "type": "string"
-        },
-        "lastName": {
-          "type": "string"
-        },
-        "father": {
-          "$ref": "#/definitions/Human"
-        },
-        "mother": {
-          "$ref": "#/definitions/Human"
-        }
-      }
-    },
-    "Error": {
-      "required": [
-        "code",
-        "message"
-      ],
-      "properties": {
-        "code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "message": {
-          "type": "string"
-        }
-      }
     }
-  }
 }

--- a/test/person.json
+++ b/test/person.json
@@ -89,7 +89,12 @@
                     "type": "string"
                 },
                 "login": {
-                    "type": "string"
+                    "type": "string",
+                    "x-swagger-mongoose": {
+                      "index": {
+                        "unique":"true"
+                      }
+                    }
                 },
                 "firstName": {
                     "type": "string"
@@ -111,7 +116,7 @@
                     "items": {
                         "type": "string",
                         "x-swagger-mongoose": {
-                            "$ref": "#/definitions/Car",
+                            "$ref": "#/definitions/Car"
                         }
                     }
                 },

--- a/test/person.json
+++ b/test/person.json
@@ -106,6 +106,17 @@
           "items": {
             "$ref": "#/definitions/Car"
           }
+        },
+        "phone": {
+          "type": "object",
+          "properties": {
+            "home": {
+              "type": "string"
+            },
+            "mobile": {
+              "type": "string"
+            }
+          }
         }
       }
     },

--- a/test/person.json
+++ b/test/person.json
@@ -112,7 +112,6 @@
                         "type": "string",
                         "x-swagger-mongoose": {
                             "$ref": "#/definitions/Car",
-                            "exclude-schema": true
                         }
                     }
                 },

--- a/test/person.json
+++ b/test/person.json
@@ -82,7 +82,13 @@
             ],
             "properties": {
                 "provider": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "Mercedes",
+                        "Jaguar",
+                        "Aston Martin",
+                        "Mazda"
+                    ]
                 },
                 "model": {
                     "type": "string"

--- a/test/person.json
+++ b/test/person.json
@@ -134,6 +134,13 @@
             }
         },
         "Human": {
+            "x-swagger-mongoose":{
+              "index":{
+                "firstName":1,
+                "lastName":1,
+                "unique":"true"
+              }
+            },
             "properties": {
                 "firstName": {
                     "type": "string"

--- a/test/person.mongoose.json
+++ b/test/person.mongoose.json
@@ -1,9 +1,0 @@
-{
-  "Person.properties.houses.items": {
-    "type": "objectId"
-  },
-  "Person.properties.cars.items": {
-    "type": "objectId",
-    "includeSwaggerRef": false
-  }
-}

--- a/test/petstore.json
+++ b/test/petstore.json
@@ -1,120 +1,127 @@
 {
-  "swagger": "2.0",
-  "info": {
-    "version": "1.0.0",
-    "title": "Swagger Petstore",
-    "contact": {
-      "name": "Swagger API Team",
-      "url": "http://swagger.io"
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Swagger Petstore",
+        "contact": {
+            "name": "Swagger API Team",
+            "url": "http://swagger.io"
+        },
+        "license": {
+            "name": "Creative Commons 4.0 International",
+            "url": "http://creativecommons.org/licenses/by/4.0/"
+        }
     },
-    "license": {
-      "name": "Creative Commons 4.0 International",
-      "url": "http://creativecommons.org/licenses/by/4.0/"
-    }
-  },
-  "host": "petstore.swagger.io",
-  "basePath": "/api",
-  "schemes": [
-    "http"
-  ],
-  "paths": {
-    "/pets": {
-      "get": {
-        "tags": ["Pet Operations"],
-        "summary": "finds pets in the system",
-        "responses": {
-          "200": {
-            "description": "pet response",
-            "schema": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Pet"
-              }
+    "host": "petstore.swagger.io",
+    "basePath": "/api",
+    "schemes": [
+        "http"
+    ],
+    "paths": {
+        "/pets": {
+            "get": {
+                "tags": [
+                    "Pet Operations"
+                ],
+                "summary": "finds pets in the system",
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Pet"
+                            }
+                        },
+                        "headers": {
+                            "x-expires": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Pet": {
+            "required": [
+                "id",
+                "name"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                },
+                "dob": {
+                    "type": "date"
+                },
+                "price": {
+                    "type": "double"
+                },
+                "sold": {
+                    "type": "boolean"
+                },
+                "friends": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "favoriteNumbers": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "address": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Address"
+                    }
+                }
             },
-            "headers": {
-              "x-expires": {
-                "type": "string"
-              }
+            "x-swagger-mongoose": {
+                "schema-options": {
+                    "timestamps": true
+                }
             }
-          },
-          "default": {
-            "description": "unexpected error",
-            "schema": {
-              "$ref": "#/definitions/Error"
+        },
+        "Address": {
+            "type": "object",
+            "properties": {
+                "addressLine1": {
+                    "type": "string"
+                }
             }
-          }
+        },
+        "Error": {
+            "required": [
+                "code",
+                "message"
+            ],
+            "properties": {
+                "code": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
         }
-      }
     }
-  },
-  "definitions": {
-    "Pet": {
-      "required": [
-        "id",
-        "name"
-      ],
-      "properties": {
-        "id": {
-          "type": "integer",
-          "format": "int64"
-        },
-        "name": {
-          "type": "string"
-        },
-        "tag": {
-          "type": "string"
-        },
-        "dob": {
-          "type": "date"
-        },
-        "price": {
-          "type": "double"
-        },
-        "sold": {
-          "type": "boolean"
-        },
-        "friends": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "favoriteNumbers": {
-          "type": "array",
-          "items": {
-            "type": "integer"
-          }
-        },
-        "address":{
-          "type":"array",
-          "items": {
-            "$ref": "#/definitions/Address"
-          }
-        }
-      }
-    },
-    "Address": {
-      "type":"object",
-      "properties": {
-        "addressLine1": {
-          "type": "string"
-        }
-      }
-    },
-    "Error": {
-      "required": [
-        "code",
-        "message"
-      ],
-      "properties": {
-        "code": {
-          "type": "integer",
-          "format": "int32"
-        },
-        "message": {
-          "type": "string"
-        }
-      }
-    }
-  }
 }


### PR DESCRIPTION
Breaking Changes: 
- forgoing the x.mongoose.json strategy in favor of x-swagger-mongoose decoration on swagger documents

Added:
-Unique Indices
-Validator support (couldn't quite get pattern=>regex to work, so I did this workaround)

Other stuff?
