### PR TITLE
Support for `additionalProperties`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -211,12 +211,21 @@ var processRef = function (property, objectName, props, key, required) {
 var getSchema = function (objectName, fullObject) {
   var props = {};
   var required = fullObject.required || [];
-  var object = fullObject['properties'] ? fullObject['properties'] : fullObject;
+  var object = fullObject['properties'];
 
   _.forEach(object, function (property, key) {
     var schemaProperty = getSchemaProperty(property, key, required, objectName, object);
-    props = _.extend(props, schemaProperty);
+    _.extend(props, schemaProperty);
   });
+
+  if (!!fullObject.additionalProperties) {
+    var customMongooseProperty = getMongooseProperty();
+    if (!props[customMongooseProperty]) {
+      props[customMongooseProperty] = {};
+    }
+    // This object includes the OpenAPI `additionalProperties` property so the schema can't be strictly defined
+    _.extend(props[customMongooseProperty], { strict: false });
+  }
 
   return props;
 };
@@ -247,6 +256,16 @@ var getSchemaProperty = function(property, key, required, objectName, object) {
   }
   else if (property.type === 'object') {
     props[key] = getSchema(key, property);
+    var customMongooseProperty = getMongooseProperty();
+    var propertyCustomOptions = props[key][customMongooseProperty];
+    if (propertyCustomOptions && propertyCustomOptions.strict === false) {
+      if (!props[customMongooseProperty]) {
+        props[customMongooseProperty] = {};
+      }
+      // Let's propagate the strict schema definition since it applies to the whole schema
+      _.extend(props[customMongooseProperty], { strict: false });
+      delete propertyCustomOptions.strict;
+    }
   }
   else if (isSimpleSchema(object)) {
     props = {type: propertyMap(object)};
@@ -317,8 +336,9 @@ module.exports.compile = function (spec, _extraDefinitions) {
       return;
     }
     object = getSchema(key, definition);
-    if (options) {
-      options = _.extend({}, options[customMongooseProperty], options[key]);
+    if (options || object[customMongooseProperty]) {
+      options = _.extend({}, object[customMongooseProperty], options[customMongooseProperty], options[key]);
+      delete object[customMongooseProperty];
     }
     if (typeof excludedSchema === 'object') {
       excludedSchema = excludedSchema[customMongooseProperty] || excludedSchema[key];

--- a/lib/index.js
+++ b/lib/index.js
@@ -359,8 +359,8 @@ var processMongooseDefinition = function(key, customOptions) {
       xSwaggerMongoose.documentIndex[key] = customOptions['index'];
     }
     if (customOptions['validators']) {
-      var validatorsDirectory = path.resolve(process.cwd(),customOptions['validators'])
-      validators = require(validatorsDirectory)
+      var validatorsDirectory = path.resolve(process.cwd(),customOptions['validators']);
+      validators = require(validatorsDirectory);
     }
 
   }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "schema"
   ],
   "author": "Simon Guest <me@simonguest.com> (http://github.com/simonguest)",
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/simonguest/swagger-mongoose/issues"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-mongoose",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Generate mongoose schemas and models from swagger documents",
   "main": "./lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -7,15 +7,15 @@
     "test": "test"
   },
   "dependencies": {
-    "lodash": "^4.6.1"
+    "lodash": "^4.16.4"
   },
   "devDependencies": {
-    "async": "^2.0.0-rc.1",
+    "async": "^2.1.1",
     "chai": "^3.5.0",
-    "mocha": "^2.4.5",
-    "mockgoose": "^6.0.0",
-    "mongodb": "^2.1.11",
-    "mongoose": "^4.4.9"
+    "mocha": "^3.1.2",
+    "mockgoose": "^6.0.8",
+    "mongodb": "^2.2.10",
+    "mongoose": "^4.6.3"
   },
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
## Changes
- Updated package version  
- Added missing commas around validators
- Updated license in package to use supported SPDX identifier
- `additionalProperties` (which valid in the OpenAPI spec was causing the plugin to crash.
  - This is now handled with propagating the `strict` option up to the Schema as `false` so that we can still define these unknown properties for our schema
- Added ability for the `getMongooseProperty()` identifier to be attached to a schema object and then appended to the schema when defining it
## TODO
- [ ] Add unit tests

@simonguest @paul42
