### PR TITLE
Required Validators On Nested Objects was not working properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - "6"
+cache: yarn

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![Travis Status](https://travis-ci.org/simonguest/swagger-mongoose.svg?branch=master)
 # swagger-mongoose-forked
+REQUIRED validation on nested working
 
 Generate mongoose schemas and models from swagger documents
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Travis Status](https://travis-ci.org/simonguest/swagger-mongoose.svg?branch=master)
-# swagger-mongoose
+# swagger-mongoose-forked
 
 Generate mongoose schemas and models from swagger documents
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -191,14 +191,15 @@ var processRef = function(property, objectName, props, key, required) {
   if (propType !== objectName) {
     var object = definitions[propType];
     if (~['array', 'object'].indexOf(object.type)) {
-      if (!xSwaggerMongoose.schemas[propType]) {
+    if (!xSwaggerMongoose.schemas[propType]) {
         var schema = getSchema(propType, object);
         
         var customMongooseProperty = getMongooseProperty();
+        
+        var options = xSwaggerMongoose.schemaOptions;
         if (object[customMongooseProperty]) {
           processMongooseDefinition(propType, object[customMongooseProperty]);
         }
-        var options = xSwaggerMongoose.schemaOptions;
         var documentIndex = xSwaggerMongoose.documentIndex;
         options = _.extend({}, options[customMongooseProperty], options[propType]);
         xSwaggerMongoose.schemas[propType] = new mongoose.Schema(schema, options);
@@ -206,8 +207,8 @@ var processRef = function(property, objectName, props, key, required) {
           documentIndex = documentIndex[customMongooseProperty] || documentIndex[propType];
         }
         processDocumentIndex(xSwaggerMongoose.schemas[propType], documentIndex);
-        
       }
+      
       var schema_nested=xSwaggerMongoose.schemas[propType];
       props[key] =property['items'] || object.type === 'array' ? {type: [schema_nested]}:{type: schema_nested};
       

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,7 @@ var xSwaggerMongoose = {
   additionalProperties: {},
   excludeSchema: {},
   documentIndex: {},
+  schemas:{}
 };
 var validators = {};
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -272,7 +272,7 @@ var getSchemaProperty = function(property, key, required, objectName, object) {
   else if (property.type === 'object') {
     if (property['properties']) {
       props[key] = getSchema(key, property);
-      props[key].type = Schema.Types.Mixed;
+      //props[key].type = Schema.Types.Mixed;
     } else {
       props[key] = {};
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,16 +37,21 @@ var propertyMap = function(property) {
       return Number;
     case 'string':
     case 'password':
+      switch (property.format) {
+        case 'date':
+        case 'date-time':
+          return Date;
+      }
       return String;
     case 'boolean':
       return Boolean;
-    case 'date':
-    case 'dateTime':
-      return Date;
     case 'array':
       return [propertyMap(property.items)];
     default:
       console.log('Warning Unrecognized schema type of ' + property)
+      _.each(property, function(val, key) {
+        console.log("pair:", key, val)
+      })
       return String;
     //throw new Error('Unrecognized schema type: ' + property.type);
   }
@@ -285,7 +290,7 @@ var getSchemaProperty = function(property, key, required, objectName, object) {
   }
   //support default
   if (property.hasOwnProperty('mdefault')) {
-    props[key].default = property.mdefault;
+    props[key]["default"] = (property.mdefault == "now") ? Date.now : property.mdefault;
   }
   return props;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 var path = require('path');
 
-var allowedTypes = ['number','integer', 'long', 'float', 'double', 'string', 'password', 'boolean', 'date', 'dateTime', 'array'];
+var allowedTypes = ['number', 'integer', 'long', 'float', 'double', 'string', 'password', 'boolean', 'date', 'dateTime', 'array'];
 var definitions = null;
 var swaggerVersion = null;
 var v2MongooseProperty = 'x-swagger-mongoose';
@@ -17,7 +17,7 @@ var xSwaggerMongoose = {
 };
 var validators = {};
 
-var propertyMap = function (property) {
+var propertyMap = function(property) {
   switch (property.type) {
     case 'number':
       switch (property.format) {
@@ -49,7 +49,7 @@ var propertyMap = function (property) {
   }
 };
 
-var convertToJSON = function (spec) {
+var convertToJSON = function(spec) {
   var swaggerJSON = {};
   var type = typeof(spec);
   switch (type) {
@@ -70,19 +70,19 @@ var convertToJSON = function (spec) {
   return swaggerJSON;
 };
 
-var isSimpleSchema = function (schema) {
+var isSimpleSchema = function(schema) {
   return schema.type && isAllowedType(schema.type);
 };
 
-var isAllowedType = function (type) {
+var isAllowedType = function(type) {
   return allowedTypes.indexOf(type) != -1;
 };
 
-var isPropertyHasRef = function (property) {
+var isPropertyHasRef = function(property) {
   return property['$ref'] || ((property['type'] == 'array') && (property['items']['$ref']));
 };
 
-var fillRequired = function (object, key, template) {
+var fillRequired = function(object, key, template) {
   if (template && Array.isArray(template) && template.indexOf(key) >= 0) {
     object[key].required = true;
   } else if (typeof template === 'boolean') {
@@ -90,13 +90,13 @@ var fillRequired = function (object, key, template) {
   }
 };
 
-var applyExtraDefinitions = function (definitions, _extraDefinitions) {
+var applyExtraDefinitions = function(definitions, _extraDefinitions) {
   if (_extraDefinitions) {
-
+    
     //TODO: check for string or object assume object for now.
     // var extraDefinitions = JSON.parse(_extraDefinitions);
     var mongooseProperty = getMongooseProperty();
-
+    
     //remove default object from extra, we're going to handle that seperately
     var defaultDefs;
     if (!_extraDefinitions.default) {
@@ -104,17 +104,17 @@ var applyExtraDefinitions = function (definitions, _extraDefinitions) {
     } else {
       defaultDefs = _extraDefinitions.default
       delete _extraDefinitions.default;
-      _.each(definitions, function (val,key){
+      _.each(definitions, function(val, key) {
         //lets add that default to everything.
         val[mongooseProperty] = defaultDefs
       });
     }
-
+    
     var extraDefinitions = _extraDefinitions;
-    _.each(extraDefinitions, function (val, key) {
+    _.each(extraDefinitions, function(val, key) {
       definitions[key][mongooseProperty] = val
     });
-
+    
   }
 };
 
@@ -126,28 +126,28 @@ var getMongooseProperty = function() {
   return (isAtLeastSwagger2()) ? v2MongooseProperty : v1MongooseProperty;
 };
 
-var isMongooseProperty = function (property) {
+var isMongooseProperty = function(property) {
   return !!property[getMongooseProperty()];
 };
 
-var isMongooseArray = function (property) {
+var isMongooseArray = function(property) {
   return property.items && property.items[getMongooseProperty()];
 };
 
-var getMongooseSpecific = function (props, property) {
+var getMongooseSpecific = function(props, property) {
   var mongooseProperty = getMongooseProperty();
   var mongooseSpecific = property[mongooseProperty];
   var ref = (isAtLeastSwagger2() && mongooseSpecific) ? mongooseSpecific.$ref : property.$ref;
-
+  
   if (!mongooseSpecific && isMongooseArray(property)) {
     mongooseSpecific = property.items[mongooseProperty];
     ref = (isAtLeastSwagger2()) ? mongooseSpecific.$ref : property.items.$ref;
   }
-
+  
   if (!mongooseSpecific) {
     return props;
   }
-
+  
   var ret = {};
   if (ref) {
     if (!isAtLeastSwagger2()) {
@@ -172,15 +172,15 @@ var getMongooseSpecific = function (props, property) {
       ret.type = propertyMap(ret);
     }
   }
-
+  
   return ret;
 };
 
-var isMongodbReserved = function (fieldKey) {
+var isMongodbReserved = function(fieldKey) {
   return fieldKey === '_id' || fieldKey === '__v';
 };
 
-var processRef = function (property, objectName, props, key, required) {
+var processRef = function(property, objectName, props, key, required) {
   var refRegExp = /^#\/definitions\/(\w*)$/;
   var refString = property['$ref'] ? property['$ref'] : property['items']['$ref'];
   var propType = refString.match(refRegExp)[1];
@@ -188,8 +188,26 @@ var processRef = function (property, objectName, props, key, required) {
   if (propType !== objectName) {
     var object = definitions[propType];
     if (~['array', 'object'].indexOf(object.type)) {
-      var schema = getSchema(propType, object['properties'] ? object['properties'] : object);
-      props[key] = property['items'] || object.type === 'array' ? [schema] : schema;
+      if (!xSwaggerMongoose.schemas[propType]) {
+        var schema = getSchema(propType, object);
+        
+        var customMongooseProperty = getMongooseProperty();
+        if (object[customMongooseProperty]) {
+          processMongooseDefinition(propType, object[customMongooseProperty]);
+        }
+        var options = xSwaggerMongoose.schemaOptions;
+        var documentIndex = xSwaggerMongoose.documentIndex;
+        options = _.extend({}, options[customMongooseProperty], options[propType]);
+        xSwaggerMongoose.schemas[propType] = new mongoose.Schema(schema, options);
+        if (typeof documentIndex === 'object') {
+          documentIndex = documentIndex[customMongooseProperty] || documentIndex[propType];
+        }
+        processDocumentIndex(xSwaggerMongoose.schemas[propType], documentIndex);
+        
+      }
+      var schema_nested = {type: xSwaggerMongoose.schemas[propType]}
+      
+      props[key] = property['items'] || object.type === 'array' ? [schema_nested] : schema_nested;
     } else {
       var clone = _.extend({}, object);
       delete clone[getMongooseProperty()];
@@ -205,19 +223,20 @@ var processRef = function (property, objectName, props, key, required) {
       };
     }
   }
-  fillRequired(props, key, required);
+  //this is all the time done in getSchemaProperty (and getSchema)
+  // fillRequired(props, key, required);
 };
 
-var getSchema = function (objectName, fullObject) {
+var getSchema = function(objectName, fullObject) {
   var props = {};
   var required = fullObject.required || [];
   var object = fullObject['properties'] ? fullObject['properties'] : fullObject;
-
-  _.forEach(object, function (property, key) {
+  
+  _.forEach(object, function(property, key) {
     var schemaProperty = getSchemaProperty(property, key, required, objectName, object);
     props = _.extend(props, schemaProperty);
   });
-
+  
   return props;
 };
 
@@ -226,7 +245,7 @@ var getSchemaProperty = function(property, key, required, objectName, object) {
   if (isMongodbReserved(key) === true) {
     return;
   }
-
+  
   if (isMongooseProperty(property)) {
     props[key] = getMongooseSpecific(props, property);
   }
@@ -238,15 +257,22 @@ var getSchemaProperty = function(property, key, required, objectName, object) {
   }
   else if (property.type !== 'object') {
     var type = propertyMap(property);
-    if (property.enum && _.isArray(property.enum)) {
+    //support array of enum with multiple values now
+    if (property.items && property.items.enum && _.isArray(property.items.enum)) {
+      props[key] = [{type: String, enum: property.items.enum}];
+    } else if (property.enum && _.isArray(property.enum)) {
       props[key] = {type: type, enum: property.enum};
     } else {
       props[key] = {type: type};
     }
-
   }
   else if (property.type === 'object') {
-    props[key] = getSchema(key, property);
+    if (property['properties']) {
+      props[key] = getSchema(key, property);
+      props[key].type = Schema.Types.Mixed;
+    } else {
+      props[key] = {};
+    }
   }
   else if (isSimpleSchema(object)) {
     props = {type: propertyMap(object)};
@@ -254,10 +280,14 @@ var getSchemaProperty = function(property, key, required, objectName, object) {
   if (required) {
     fillRequired(props, key, required);
   }
+  //support default
+  if (property.hasOwnProperty('mdefault')) {
+    props[key].default = property.mdefault;
+  }
   return props;
 };
 
-var processDocumentIndex = function(schema, index){
+var processDocumentIndex = function(schema, index) {
   //TODO: check indicies are numbers
   var isUniqueIndex = false;
   if (_.isEmpty(index)) {
@@ -268,15 +298,14 @@ var processDocumentIndex = function(schema, index){
   }
   delete index.unique;
   if (isUniqueIndex) {
-    schema.index(index, {unique:true})
+    schema.index(index, {unique: true})
   } else {
     schema.index(index)
   }
-
+  
 };
 
-
-module.exports.compileAsync = function (spec, callback) {
+module.exports.compileAsync = function(spec, callback) {
   try {
     callback(null, this.compile(spec));
   } catch (err) {
@@ -284,32 +313,37 @@ module.exports.compileAsync = function (spec, callback) {
   }
 };
 
-module.exports.compile = function (spec, _extraDefinitions) {
+module.exports.compile = function(spec, _extraDefinitions) {
   if (!spec) throw new Error('Swagger spec not supplied');
   var swaggerJSON = convertToJSON(spec);
   if (swaggerJSON.swagger) {
     swaggerVersion = new Number(swaggerJSON.swagger);
   }
-
-
-
+  
   definitions = swaggerJSON['definitions'];
-
+  
   applyExtraDefinitions(definitions, _extraDefinitions);
-
+  
   var customMongooseProperty = getMongooseProperty();
-
+  
   if (swaggerJSON[customMongooseProperty]) {
     processMongooseDefinition(customMongooseProperty, swaggerJSON[customMongooseProperty]);
   }
-
+  
   var schemas = {};
-  _.forEach(definitions, function (definition, key) {
+  _.forEach(definitions, function(definition, key) {
     var object;
     var options = xSwaggerMongoose.schemaOptions;
     var excludedSchema = xSwaggerMongoose.excludeSchema;
-    var documentIndex = xSwaggerMongoose.documentIndex[key];
-
+    //this mods else documentIndex is not a ref to a var and we wont change it after processMongooseDefinition
+    var documentIndex = xSwaggerMongoose.documentIndex;
+    
+    if (xSwaggerMongoose.schemas[key]) {
+      //this schema was already parsed (from nested properties)
+      schemas[key] = xSwaggerMongoose.schemas[key];
+      return;
+    }
+    
     if (definition[customMongooseProperty]) {
       processMongooseDefinition(key, definition[customMongooseProperty]);
     }
@@ -323,21 +357,26 @@ module.exports.compile = function (spec, _extraDefinitions) {
     if (typeof excludedSchema === 'object') {
       excludedSchema = excludedSchema[customMongooseProperty] || excludedSchema[key];
     }
+    if (typeof documentIndex === 'object') {
+      documentIndex = documentIndex[customMongooseProperty] || documentIndex[key];
+    }
     if (object && !excludedSchema) {
       var additionalProperties = _.extend({}, xSwaggerMongoose.additionalProperties[customMongooseProperty], xSwaggerMongoose.additionalProperties[key]);
       additionalProperties = processAdditionalProperties(additionalProperties, key)
       object = _.extend(object, additionalProperties);
       var schema = new mongoose.Schema(object, options);
-      processDocumentIndex(schema, documentIndex)
-      schemas[key] = schema
+      processDocumentIndex(schema, documentIndex);
+      schemas[key] = schema;
+      //save the parse to not do it again in case of duplicate (in nested)
+      xSwaggerMongoose.schemas[key] = schema;
     }
   });
-
+  
   var models = {};
-  _.forEach(schemas, function (schema, key) {
+  _.forEach(schemas, function(schema, key) {
     models[key] = mongoose.model(key, schema);
   });
-
+  
   return {
     schemas: schemas,
     models: models
@@ -359,20 +398,21 @@ var processMongooseDefinition = function(key, customOptions) {
       xSwaggerMongoose.documentIndex[key] = customOptions['index'];
     }
     if (customOptions['validators']) {
-      var validatorsDirectory = path.resolve(process.cwd(),customOptions['validators'])
+      var validatorsDirectory = path.resolve(process.cwd(), customOptions['validators'])
       validators = require(validatorsDirectory)
     }
-
+    
   }
 };
 
 var processAdditionalProperties = function(additionalProperties, objectName) {
   var props = {};
   var customMongooseProperty = getMongooseProperty();
-  _.each(additionalProperties, function (property, key) {
-    var modifiedProperty = {};
-    modifiedProperty[customMongooseProperty] = property;
-    props = _.extend(props, getSchemaProperty(modifiedProperty, key, property.required, objectName));
+  _.each(additionalProperties, function(property, key) {
+    //  var modifiedProperty = {};
+    //   modifiedProperty[customMongooseProperty] = property;
+    // not good for array of x-swagger-mongoose
+    props = _.extend(props, getSchemaProperty(property, key, property.required, objectName));
   });
   return props;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -208,9 +208,9 @@ var processRef = function(property, objectName, props, key, required) {
         processDocumentIndex(xSwaggerMongoose.schemas[propType], documentIndex);
         
       }
-      var schema_nested = {type: xSwaggerMongoose.schemas[propType]}
+      var schema_nested=xSwaggerMongoose.schemas[propType];
+      props[key] =property['items'] || object.type === 'array' ? {type: [schema_nested]}:{type: schema_nested};
       
-      props[key] = property['items'] || object.type === 'array' ? [schema_nested] : schema_nested;
     } else {
       var clone = _.extend({}, object);
       delete clone[getMongooseProperty()];

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,9 @@ var propertyMap = function(property) {
     case 'array':
       return [propertyMap(property.items)];
     default:
-      throw new Error('Unrecognized schema type: ' + property.type);
+    console.log('Warning Unrecognized schema type of ' + property)
+    return String;
+      //throw new Error('Unrecognized schema type: ' + property.type);
   }
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -196,12 +196,13 @@ var processRef = function(property, objectName, props, key, required) {
         
         var customMongooseProperty = getMongooseProperty();
         
-        applyExtraDefinitions(definitions, xSwaggerMongoose._extraDefinitions);
         
         var options = xSwaggerMongoose.schemaOptions;
         if (object[customMongooseProperty]) {
           processMongooseDefinition(propType, object[customMongooseProperty]);
         }
+        applyExtraDefinitions(definitions, xSwaggerMongoose._extraDefinitions);
+        
         var documentIndex = xSwaggerMongoose.documentIndex;
         options = _.extend({}, options[customMongooseProperty], options[propType]);
         xSwaggerMongoose.schemas[propType] = new mongoose.Schema(schema, options);
@@ -329,7 +330,6 @@ module.exports.compile = function(spec, _extraDefinitions) {
   definitions = swaggerJSON['definitions'];
   
   xSwaggerMongoose._extraDefinitions=_extraDefinitions;
-  applyExtraDefinitions(definitions, _extraDefinitions);
   
   var customMongooseProperty = getMongooseProperty();
   
@@ -354,6 +354,9 @@ module.exports.compile = function(spec, _extraDefinitions) {
     if (definition[customMongooseProperty]) {
       processMongooseDefinition(key, definition[customMongooseProperty]);
     }
+    
+  applyExtraDefinitions(definitions, _extraDefinitions);
+  
     if (excludedSchema[key]) {
       return;
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -196,6 +196,8 @@ var processRef = function(property, objectName, props, key, required) {
         
         var customMongooseProperty = getMongooseProperty();
         
+        applyExtraDefinitions(definitions, xSwaggerMongoose._extraDefinitions);
+        
         var options = xSwaggerMongoose.schemaOptions;
         if (object[customMongooseProperty]) {
           processMongooseDefinition(propType, object[customMongooseProperty]);
@@ -326,6 +328,7 @@ module.exports.compile = function(spec, _extraDefinitions) {
   
   definitions = swaggerJSON['definitions'];
   
+  xSwaggerMongoose._extraDefinitions=_extraDefinitions;
   applyExtraDefinitions(definitions, _extraDefinitions);
   
   var customMongooseProperty = getMongooseProperty();

--- a/lib/index.js
+++ b/lib/index.js
@@ -196,12 +196,11 @@ var processRef = function(property, objectName, props, key, required) {
         
         var customMongooseProperty = getMongooseProperty();
         
-        
         var options = xSwaggerMongoose.schemaOptions;
         if (object[customMongooseProperty]) {
           processMongooseDefinition(propType, object[customMongooseProperty]);
         }
-        applyExtraDefinitions(definitions, xSwaggerMongoose._extraDefinitions);
+        
         
         var documentIndex = xSwaggerMongoose.documentIndex;
         options = _.extend({}, options[customMongooseProperty], options[propType]);
@@ -329,7 +328,7 @@ module.exports.compile = function(spec, _extraDefinitions) {
   
   definitions = swaggerJSON['definitions'];
   
-  xSwaggerMongoose._extraDefinitions=_extraDefinitions;
+  applyExtraDefinitions(definitions, _extraDefinitions);
   
   var customMongooseProperty = getMongooseProperty();
   
@@ -354,16 +353,22 @@ module.exports.compile = function(spec, _extraDefinitions) {
     if (definition[customMongooseProperty]) {
       processMongooseDefinition(key, definition[customMongooseProperty]);
     }
-    
-  applyExtraDefinitions(definitions, _extraDefinitions);
-  
     if (excludedSchema[key]) {
       return;
     }
     object = getSchema(key, definition);
+    /*
     if (options) {
       options = _.extend({}, options[customMongooseProperty], options[key]);
     }
+    */
+    if (options) {
+      var opt = options[customMongooseProperty] ? options[customMongooseProperty] : {};
+      options = _.extend(opt, options[key]);
+    }
+    console.info("testsim",key)
+    console.info(options)
+    
     if (typeof excludedSchema === 'object') {
       excludedSchema = excludedSchema[customMongooseProperty] || excludedSchema[key];
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ var xSwaggerMongoose = {
   additionalProperties: {},
   excludeSchema: {},
   documentIndex: {},
-  schemas:{}
+  nextedschemas: {}
 };
 var validators = {};
 
@@ -46,9 +46,9 @@ var propertyMap = function(property) {
     case 'array':
       return [propertyMap(property.items)];
     default:
-    console.log('Warning Unrecognized schema type of ' + property)
-    return String;
-      //throw new Error('Unrecognized schema type: ' + property.type);
+      console.log('Warning Unrecognized schema type of ' + property)
+      return String;
+    //throw new Error('Unrecognized schema type: ' + property.type);
   }
 };
 
@@ -191,7 +191,7 @@ var processRef = function(property, objectName, props, key, required) {
   if (propType !== objectName) {
     var object = definitions[propType];
     if (~['array', 'object'].indexOf(object.type)) {
-    if (!xSwaggerMongoose.schemas[propType]) {
+      if (!xSwaggerMongoose.nextedschemas[propType]) {
         var schema = getSchema(propType, object);
         
         var customMongooseProperty = getMongooseProperty();
@@ -200,19 +200,16 @@ var processRef = function(property, objectName, props, key, required) {
         if (object[customMongooseProperty]) {
           processMongooseDefinition(propType, object[customMongooseProperty]);
         }
-        
-        
         var documentIndex = xSwaggerMongoose.documentIndex;
         options = _.extend({}, options[customMongooseProperty], options[propType]);
-        xSwaggerMongoose.schemas[propType] = new mongoose.Schema(schema, options);
+        xSwaggerMongoose.nextedschemas[propType] = new mongoose.Schema(schema, options);
         if (typeof documentIndex === 'object') {
           documentIndex = documentIndex[customMongooseProperty] || documentIndex[propType];
         }
-        processDocumentIndex(xSwaggerMongoose.schemas[propType], documentIndex);
+        processDocumentIndex(xSwaggerMongoose.nextedschemas[propType], documentIndex);
       }
-      
-      var schema_nested=xSwaggerMongoose.schemas[propType];
-      props[key] =property['items'] || object.type === 'array' ? {type: [schema_nested]}:{type: schema_nested};
+      var schema_nested = xSwaggerMongoose.nextedschemas[propType];
+      props[key] = property['items'] || object.type === 'array' ? {type: [schema_nested]} : {type: schema_nested};
       
     } else {
       var clone = _.extend({}, object);
@@ -335,8 +332,8 @@ module.exports.compile = function(spec, _extraDefinitions) {
   if (swaggerJSON[customMongooseProperty]) {
     processMongooseDefinition(customMongooseProperty, swaggerJSON[customMongooseProperty]);
   }
-  
-  var schemas = {};
+  //for recompilation  (ex test case) reinit nextedschemas
+  var schemas = xSwaggerMongoose.nextedschemas = {};
   _.forEach(definitions, function(definition, key) {
     var object;
     var options = xSwaggerMongoose.schemaOptions;
@@ -344,9 +341,9 @@ module.exports.compile = function(spec, _extraDefinitions) {
     //this mods else documentIndex is not a ref to a var and we wont change it after processMongooseDefinition
     var documentIndex = xSwaggerMongoose.documentIndex;
     
-    if (xSwaggerMongoose.schemas[key]) {
+    if (xSwaggerMongoose.nextedschemas[key]) {
       //this schema was already parsed (from nested properties)
-      schemas[key] = xSwaggerMongoose.schemas[key];
+      schemas[key] = xSwaggerMongoose.nextedschemas[key];
       return;
     }
     
@@ -357,17 +354,10 @@ module.exports.compile = function(spec, _extraDefinitions) {
       return;
     }
     object = getSchema(key, definition);
-    /*
-    if (options) {
-      options = _.extend({}, options[customMongooseProperty], options[key]);
-    }
-    */
     if (options) {
       var opt = options[customMongooseProperty] ? options[customMongooseProperty] : {};
       options = _.extend(opt, options[key]);
     }
-    console.info("testsim",key)
-    console.info(options)
     
     if (typeof excludedSchema === 'object') {
       excludedSchema = excludedSchema[customMongooseProperty] || excludedSchema[key];
@@ -383,7 +373,7 @@ module.exports.compile = function(spec, _extraDefinitions) {
       processDocumentIndex(schema, documentIndex);
       schemas[key] = schema;
       //save the parse to not do it again in case of duplicate (in nested)
-      xSwaggerMongoose.schemas[key] = schema;
+      xSwaggerMongoose.nextedschemas[key] = schema;
     }
   });
   


### PR DESCRIPTION
-> Required Validators On Nested Objects fixed
with required on nested object i had a error from mongoose:: /Cannot.*'required'/ As well i could enter any object when i create the validation of schema is not working.

See http://mongoosejs.com/docs/validation.html
Chapitre:
« Required Validators On Nested Objects »

The return getSchema isn't a full fledged path , need to use a single nested schema else the user can enter any schema object the validation will pass (mongoose will comporte as a type Mixed.
Solution:
Fixed properly validation check with nested object process ref should to return a type to a Object mongoose.schema and not a simple javascript object.

there is as well different bug fixed
Was tested with last swagger.