### PR TITLE
Bug Fixing: document indexes don't apply

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -306,13 +306,12 @@ module.exports.compile = function (spec, _extraDefinitions) {
   var schemas = {};
   _.forEach(definitions, function (definition, key) {
     var object;
-    var options = xSwaggerMongoose.schemaOptions;
-    var excludedSchema = xSwaggerMongoose.excludeSchema;
-    var documentIndex = xSwaggerMongoose.documentIndex[key];
-
     if (definition[customMongooseProperty]) {
       processMongooseDefinition(key, definition[customMongooseProperty]);
     }
+    var options = xSwaggerMongoose.schemaOptions;
+    var excludedSchema = xSwaggerMongoose.excludeSchema;
+    var documentIndex = xSwaggerMongoose.documentIndex[key];
     if (excludedSchema[key]) {
       return;
     }
@@ -328,8 +327,8 @@ module.exports.compile = function (spec, _extraDefinitions) {
       additionalProperties = processAdditionalProperties(additionalProperties, key)
       object = _.extend(object, additionalProperties);
       var schema = new mongoose.Schema(object, options);
-      processDocumentIndex(schema, documentIndex)
-      schemas[key] = schema
+      processDocumentIndex(schema, documentIndex);
+      schemas[key] = schema;
     }
   });
 


### PR DESCRIPTION
that was because initializing items:
```
var options = xSwaggerMongoose.schemaOptions;
var excludedSchema = xSwaggerMongoose.excludeSchema;
var documentIndex = xSwaggerMongoose.documentIndex[key];
```
 were before loading schema definitions:
```
if (definition[customMongooseProperty]) {
    processMongooseDefinition(key, definition[customMongooseProperty]);
}