### PR TITLE
OpenAPIv3 support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -181,7 +181,7 @@ var isMongodbReserved = function (fieldKey) {
 };
 
 var processRef = function (property, objectName, props, key, required) {
-  var refRegExp = /^#\/definitions\/(\w*)$/;
+  var refRegExp = /^#\/components\/schemas\/(\w*)$/;
   var refString = property['$ref'] ? property['$ref'] : property['items']['$ref'];
   var propType = refString.match(refRegExp)[1];
   // NOT circular reference
@@ -325,7 +325,7 @@ module.exports.compile = function (spec, _extraDefinitions) {
     }
     if (object && !excludedSchema) {
       var additionalProperties = _.extend({}, xSwaggerMongoose.additionalProperties[customMongooseProperty], xSwaggerMongoose.additionalProperties[key]);
-      additionalProperties = processAdditionalProperties(additionalProperties, key)
+      additionalProperties = processAdditionalProperties(additionalProperties, key);
       object = _.extend(object, additionalProperties);
       var schema = new mongoose.Schema(object, options);
       processDocumentIndex(schema, documentIndex)

--- a/lib/index.js
+++ b/lib/index.js
@@ -181,7 +181,12 @@ var isMongodbReserved = function (fieldKey) {
 };
 
 var processRef = function (property, objectName, props, key, required) {
-  var refRegExp = /^#\/components\/schemas\/(\w*)$/;
+  var refRegExp;
+  if (swaggerVersion >= 3) {
+    refRegExp = /^#\/components\/schemas\/(\w*)$/;
+  } else {
+    refRegExp = /^#\/definitions\/(\w*)$/;
+  }
   var refString = property['$ref'] ? property['$ref'] : property['items']['$ref'];
   var propType = refString.match(refRegExp)[1];
   // NOT circular reference
@@ -293,7 +298,12 @@ module.exports.compile = function (spec, _extraDefinitions) {
 
 
 
-  definitions = swaggerJSON['components']['schemas'];
+  if (swaggerVersion >= 3) {
+    definitions = swaggerJSON['components']['schemas'];
+  } else {
+    definitions = swaggerJSON['definitions'];
+  }
+
 
   applyExtraDefinitions(definitions, _extraDefinitions);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,7 +90,7 @@ var fillRequired = function (object, key, template) {
   }
 };
 
-var applyExtraDefinitions = function (definitions, _extraDefinitions) {
+var applyExtraDefinitions = function (definitions,  _extraDefinitions) {
   if (_extraDefinitions) {
 
     //TODO: check for string or object assume object for now.
@@ -288,12 +288,12 @@ module.exports.compile = function (spec, _extraDefinitions) {
   if (!spec) throw new Error('Swagger spec not supplied');
   var swaggerJSON = convertToJSON(spec);
   if (swaggerJSON.swagger) {
-    swaggerVersion = new Number(swaggerJSON.swagger);
+    swaggerVersion = Number(swaggerJSON.swagger);
   }
 
 
 
-  definitions = swaggerJSON['definitions'];
+  definitions = swaggerJSON['components']['schemas'];
 
   applyExtraDefinitions(definitions, _extraDefinitions);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -294,6 +294,9 @@ module.exports.compile = function (spec, _extraDefinitions) {
   var swaggerJSON = convertToJSON(spec);
   if (swaggerJSON.swagger) {
     swaggerVersion = Number(swaggerJSON.swagger);
+  } else if(swaggerJSON.openapi) {
+    // Rough and ready semver parse to get major version number
+    swaggerVersion = Number(swaggerJSON.openapi.split('.')[0]);
   }
 
 


### PR DESCRIPTION
This PR adds support for OpenAPI v3, which moved `definitions` to `components/schemas`. Includes conditional to retain backwards compatibility with Swagger v2.